### PR TITLE
Demo linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 content
 dist
+lib
 node_modules
 *.bundle.js
 *.log

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "A mighty, modern CSS linter that helps you enforce consistent conventions and avoid errors in your stylesheets.",
   "googleAnalyticsUA": "UA-72480048-1",
   "scripts": {
+    "bundle-stylelint": "webpack --config scripts/bundle-stylelint/webpack.config.babel.js",
     "lint:js": "eslint --ignore-path .gitignore --fix .",
     "lint:css": "stylelint \"web_modules/**/*.css\"",
     "lint": "npm-run-all --parallel lint:*",
@@ -14,9 +15,9 @@
     "docs:copy": "babel-node ./scripts/copy-stylelint-docs",
     "docs:process": "babel-node ./scripts/process-stylelint-docs",
     "docs": "npm run docs:copy && npm run docs:process",
-    "prebuild": "npm run docs",
+    "prebuild": "npm run docs && npm run bundle-stylelint",
     "build": "phenomic build",
-    "prestart": "npm run docs",
+    "prestart": "npm run docs && npm run bundle-stylelint",
     "start": "phenomic start",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist -r git@github.com:stylelint/stylelint.github.io.git -b master"
@@ -104,6 +105,7 @@
     "webpack": "^1.13.0"
   },
   "dependencies": {
+    "codemirror": "^5.13.4",
     "history": "^2.1.0",
     "codemirror": "^5.13.4",
     "invariant": "^2.2.1",
@@ -117,6 +119,6 @@
     "react": "^15.0.1",
     "react-topbar-progress-indicator": "^1.0.0",
     "redux": "^3.5.1",
-    "whatwg-fetch": "^0.11.1"
+    "whatwg-fetch": "^0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     }
   },
   "stylelint": {
+    "ignoreFiles": "**/codemirror/**/*.css",
     "extends": "stylelint-config-standard",
     "rules": {
       "declaration-block-properties-order": [
@@ -99,8 +100,11 @@
   },
   "dependencies": {
     "history": "^2.1.0",
+    "codemirror": "^5.13.4",
     "invariant": "^2.2.1",
     "react": "^15.0.1",
+    "lodash.debounce": "^4.0.6",
+    "react-codemirror": "^0.2.6",
     "react-dom": "^15.0.1",
     "react-google-analytics": "^0.2.0",
     "react-helmet": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,13 @@
       "eslint-config-i-am-meticulous/react"
     ],
     "rules": {
-      "react/prefer-stateless-function": 0
+      "react/prefer-stateless-function": 0,
+      "react/jsx-no-bind": [
+        2,
+        {
+          "ignoreRefs": true
+        }
+      ]
     }
   },
   "stylelint": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     }
   },
   "stylelint": {
-    "ignoreFiles": "**/codemirror/**/*.css",
     "extends": "stylelint-config-standard",
     "rules": {
       "declaration-block-properties-order": [
@@ -108,7 +107,6 @@
     "history": "^2.1.0",
     "codemirror": "^5.13.4",
     "invariant": "^2.2.1",
-    "react": "^15.0.1",
     "lodash.debounce": "^4.0.6",
     "react-codemirror": "^0.2.6",
     "react-dom": "^15.0.1",
@@ -116,6 +114,7 @@
     "react-helmet": "^3.1.0",
     "react-redux": "^4.4.5",
     "react-router": "^2.3.0",
+    "react": "^15.0.1",
     "react-topbar-progress-indicator": "^1.0.0",
     "redux": "^3.5.1",
     "whatwg-fetch": "^0.11.1"

--- a/scripts/bundle-stylelint/build-config-shim.js
+++ b/scripts/bundle-stylelint/build-config-shim.js
@@ -1,0 +1,9 @@
+"use strict"
+
+module.exports = function(options) {
+  if (options.config) {
+    return Promise.resolve({ config: options.config })
+  }
+
+  return Promise.reject(new Error("Unable to build stylelint config"))
+}

--- a/scripts/bundle-stylelint/empty-module.js
+++ b/scripts/bundle-stylelint/empty-module.js
@@ -1,0 +1,1 @@
+export default null

--- a/scripts/bundle-stylelint/stylelint-browser-bundle.js
+++ b/scripts/bundle-stylelint/stylelint-browser-bundle.js
@@ -1,0 +1,3 @@
+import { lint } from "stylelint"
+
+export default lint

--- a/scripts/bundle-stylelint/webpack.config.babel.js
+++ b/scripts/bundle-stylelint/webpack.config.babel.js
@@ -1,0 +1,54 @@
+import webpack from "webpack"
+import path from "path"
+
+export default {
+  entry: path.join(__dirname, "stylelint-browser-bundle.js"),
+  output: {
+    path: path.resolve(__dirname, "..", "..", "lib"),
+    filename: "stylelint-browser-bundle.js",
+    libraryTarget: "commonjs2",
+    library: "StylelintBrowserBundle",
+  },
+  resolve: {
+    root: [ path.resolve(__dirname) ],
+    alias: {
+      "cosmiconfig": "empty-module",
+      "doiuse": "empty-module",
+      "globby": "empty-module",
+      "globjoin": "empty-module",
+      "multimatch": "empty-module",
+      "path": "empty-module",
+      "resolve-from": "empty-module",
+    },
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loader: "babel-loader",
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.json$/,
+        loader: "json-loader",
+      },
+    ],
+  },
+  plugins: [
+    // resolve.alias does not resolve relative require statements, replace the
+    // buildConfig module via this plugin instead
+    new webpack.NormalModuleReplacementPlugin(
+      /buildConfig\.js$/,
+      path.resolve(__dirname, "build-config-shim.js")
+    ),
+    // stylelint's postcssPlugin dynamically requires stylelint plugins which
+    // are not used in the browser. Tell Webpack to ignore them. See
+    // https://github.com/webpack/webpack/issues/198
+    new webpack.ContextReplacementPlugin(/stylelint/, /NEVER_MATCH^/),
+  ],
+  node: {
+    fs: "empty",
+    module: "empty",
+  },
+}

--- a/scripts/copy-stylelint-docs.js
+++ b/scripts/copy-stylelint-docs.js
@@ -26,3 +26,16 @@ rootFiles.forEach(function(file) {
 
 // rename main readme
 fs.renameSync("content/README.md", "content/index.md")
+
+// create demo.md
+const demo = `---
+title: Demo
+description: Try stylelint in your browser
+layout: Demo
+---
+`
+const demoPath = "content/demo"
+if (!fs.existsSync(demoPath)) {
+  fs.mkdirSync(demoPath)
+}
+fs.writeFileSync(`${demoPath}/index.md`, demo)

--- a/scripts/copy-stylelint-docs.js
+++ b/scripts/copy-stylelint-docs.js
@@ -31,7 +31,7 @@ fs.renameSync("content/README.md", "content/index.md")
 const demo = `---
 title: Demo
 description: Try stylelint in your browser
-layout: Demo
+layout: DemoPage
 ---
 `
 const demoPath = "content/demo"

--- a/scripts/webpack.config.client.js
+++ b/scripts/webpack.config.client.js
@@ -39,7 +39,7 @@ export default ({ config }) => {
     plugins: [
       ...webpackConfig.plugins,
       new webpack.optimize.CommonsChunkPlugin(
-        "statinamic-client",
+        "phenomic-client",
         "[name].[hash].js",
         Infinity,
       ),

--- a/scripts/webpack.config.client.js
+++ b/scripts/webpack.config.client.js
@@ -1,0 +1,48 @@
+import path from "path"
+import webpack from "webpack"
+
+// ! client side loader only \\
+export default ({ config }) => {
+  const { webpackConfig } = config
+  return {
+    ...webpackConfig,
+    module: {
+      ...webpackConfig.module,
+      loaders: [
+        ...webpackConfig.module.loaders,
+        {
+          test: /\.json$/,
+          loader: "json-loader",
+        },
+        {
+          test: /\.js$/,
+          loaders: [
+            `babel-loader${
+              config.dev ? "?presets[]=babel-preset-react-hmre" : ""
+            }`,
+            "eslint-loader?fix",
+          ],
+          include: [
+            path.resolve(config.cwd, "scripts"),
+            path.resolve(config.cwd, "web_modules"),
+          ],
+        },
+      ],
+    },
+
+    noParse: [ /stylelint-browser-bundle/, /react-codemirror/, /codemirror/ ],
+
+    entry: {
+      "phenomic-client": path.join(__dirname, "index-client"),
+    },
+
+    plugins: [
+      ...webpackConfig.plugins,
+      new webpack.optimize.CommonsChunkPlugin(
+        "statinamic-client",
+        "[name].[hash].js",
+        Infinity,
+      ),
+    ],
+  }
+}

--- a/web_modules/Demo/codemirror.css
+++ b/web_modules/Demo/codemirror.css
@@ -1,0 +1,4 @@
+:global {
+  @import "~codemirror/lib/codemirror.css";
+  @import "~codemirror/theme/eclipse.css";
+}

--- a/web_modules/Demo/index.css
+++ b/web_modules/Demo/index.css
@@ -1,23 +1,21 @@
-.root {
-  padding: 0 1rem;
-}
-
 .input {
-  border: 1px solid grey;
-  margin-top: 1em;
   max-width: 100%;
   min-height: 300px;
 }
 
 .results {
-  margin-top: 1em;
+  background: whitesmoke;
+  border: 1px solid gainsboro;
+  border-width: 1px 0;
+  padding: 1rem 0.5rem;
 }
 
 .console {
-  color: crimson;
+  background: crimson;
+  border: 1px solid gainsboro;
+  border-width: 1px 0;
+  color: white;
   display: block;
   font-family: "Oxygen Mono", monospace;
-  font-weight: bold;
-  margin: 1em auto;
-  white-space: pre;
+  padding: 1rem 0.5rem;
 }

--- a/web_modules/Demo/index.css
+++ b/web_modules/Demo/index.css
@@ -1,0 +1,14 @@
+.root { /* placeholder */ }
+.section { /* placholder */ }
+.results { /* placholder */ }
+
+.code,
+.config {
+  min-height: 300px;
+  width: 100%;
+}
+
+.console {
+  color: red;
+  font-weight: bold;
+}

--- a/web_modules/Demo/index.css
+++ b/web_modules/Demo/index.css
@@ -1,14 +1,22 @@
-.root { /* placeholder */ }
-.section { /* placholder */ }
-.results { /* placholder */ }
+.root {
+  padding: 0 1rem;
+}
 
-.code,
-.config {
+.input {
+  border: 1px solid #b3b3b3;
+  margin-top: 1em;
+  max-width: 100%;
   min-height: 300px;
-  width: 100%;
+}
+
+.results {
+  margin-top: 1em;
 }
 
 .console {
-  color: red;
+  color: crimson;
+  display: block;
+  font-family: "Oxygen Mono", monospace;
   font-weight: bold;
+  white-space: pre;
 }

--- a/web_modules/Demo/index.css
+++ b/web_modules/Demo/index.css
@@ -3,7 +3,7 @@
 }
 
 .input {
-  border: 1px solid #b3b3b3;
+  border: 1px solid grey;
   margin-top: 1em;
   max-width: 100%;
   min-height: 300px;
@@ -18,5 +18,6 @@
   display: block;
   font-family: "Oxygen Mono", monospace;
   font-weight: bold;
+  margin: 1em auto;
   white-space: pre;
 }

--- a/web_modules/Demo/index.js
+++ b/web_modules/Demo/index.js
@@ -3,11 +3,14 @@ import Codemirror from "react-codemirror"
 import LintWarnings from "../LintWarnings/"
 import debounce from "lodash.debounce"
 import standardConfig from "stylelint-config-standard"
-import stylelintBrowserBundle from "stylelint-browser-bundle"
+import stylelintBrowserBundle from "../../lib/stylelint-browser-bundle.js"
 
 import "codemirror/mode/css/css"
 import "codemirror/mode/javascript/javascript"
 
+// leading ! disables existing webpack config. See explanation at:
+// https://github.com/webpack/css-loader/issues/80#issuecomment-214222195
+import "!style!css!./codemirror.css"
 import styles from "./index.css"
 
 export default class Demo extends Component {

--- a/web_modules/Demo/index.js
+++ b/web_modules/Demo/index.js
@@ -1,0 +1,100 @@
+import React, { Component } from "react"
+import standardConfig from "stylelint-config-standard"
+import stylelintBrowserBundle from "stylelint-browser-bundle"
+
+import styles from "./index.css"
+
+export default class Demo extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      config: standardConfig,
+      code: "a {} b {color: #FFF; }",
+      errors: [],
+      warnings: [],
+    }
+    this.lint = this.lint.bind(this)
+    this.updateCode = this.updateCode.bind(this)
+    this.updateConfig = this.updateConfig.bind(this)
+  }
+
+  componentDidMount() {
+    this.lint()
+  }
+
+  lint() {
+    if (this.state.error) return
+
+    stylelintBrowserBundle(this.state)
+      .then(output => {
+        this.setState({
+          warnings: output.results[0].warnings,
+          error: false,
+        })
+      }).catch(err => {
+        this.setState({
+          error: `Failed to lint CSS! \n\n ${err}`,
+          warnings: [],
+        })
+      })
+  }
+
+  updateCode(event) {
+    this.setState({
+      code: event.target.value,
+      error: false,
+    }, this.lint)
+  }
+
+  updateConfig(event) {
+    let nextState
+
+    try {
+      nextState = {
+        config: JSON.parse(event.target.value),
+        error: false,
+      }
+    }
+    catch (err) {
+      nextState = {
+        error: `There was a problem with the config:\n\n ${err}`,
+        warnings: [],
+      }
+    }
+
+    this.setState(nextState, this.lint)
+  }
+
+  render() {
+    return (
+      <div className={ styles.root }>
+        <div className={ styles.section }>
+          <textarea
+            className={ styles.code }
+            spellCheck="false"
+            defaultValue={ this.state.code }
+            onChange={ this.updateCode }
+          ></textarea>
+        </div>
+        <div className={ styles.section }>
+          <pre className={ styles.results }>
+            {
+              this.state.warnings.map(w =>
+                `Line ${w.line}, Col ${w.column}: ${w.text}\n`
+              )
+            }
+          </pre>
+          <div className={ styles.console }>{ this.state.error }</div>
+        </div>
+        <div className={ styles.section }>
+          <textarea
+            className={ styles.config }
+            spellCheck="false"
+            defaultValue={ JSON.stringify(this.state.config, null, 2) }
+            onChange={ this.updateConfig }
+          ></textarea>
+        </div>
+      </div>
+    )
+  }
+}

--- a/web_modules/Demo/index.js
+++ b/web_modules/Demo/index.js
@@ -27,8 +27,8 @@ export default class Demo extends Component {
 
     this.lint = this.lint.bind(this)
     this.parseConfig = this.parseConfig.bind(this)
-    this.updateCode = this.updateCode.bind(this)
-    this.updateConfig = this.updateConfig.bind(this)
+    this.handleCode = this.handleCode.bind(this)
+    this.handleConfig = this.handleConfig.bind(this)
   }
 
   componentDidMount() {
@@ -82,14 +82,14 @@ export default class Demo extends Component {
     }
   }
 
-  updateCode(code) {
+  handleCode(code) {
     this.setState({
       code,
       error: false,
     }, this.lint)
   }
 
-  updateConfig(config) {
+  handleConfig(config) {
     this.setState({
       config,
       error: false,
@@ -104,7 +104,7 @@ export default class Demo extends Component {
             ref={ ref => this.codeMirrorRefs[0] = ref }
             name={ "code" }
             value={ this.state.code }
-            onChange={ this.updateCode }
+            onChange={ this.handleCode }
             options={ {
               mode: "css",
               theme: "eclipse",
@@ -121,7 +121,7 @@ export default class Demo extends Component {
           name={ "config" }
           className={ styles.input }
           value={ this.state.config }
-          onChange={ this.updateConfig }
+          onChange={ this.handleConfig }
           options={ {
             mode: { name: "javascript", json: true },
             theme: "eclipse",
@@ -144,7 +144,7 @@ export default class Demo extends Component {
   theme="github"
   className={ styles.section }
   value={ this.state.code }
-  onChange={ this.updateCode }
+  onChange={ this.handleCode }
   showPrintMargin={ false }
   editorProps={ {
     useWorker: false,

--- a/web_modules/Demo/index.js
+++ b/web_modules/Demo/index.js
@@ -120,7 +120,9 @@ export default class Demo extends Component {
             lineNumbers: true,
           } }
         />
-        { this.state.errors.length > 0 ? error : warnings }
+        <output className={ styles.output }>
+          { this.state.errors.length > 0 ? error : warnings }
+        </output>
         <Codemirror
           ref={ ref => this.codeMirrorRefs[1] = ref }
           name={ "config" }

--- a/web_modules/Demo/loader.js
+++ b/web_modules/Demo/loader.js
@@ -1,0 +1,15 @@
+"use strict"
+
+// Allow Demo component to be required at run-time
+// See https://webpack.github.io/docs/code-splitting.html
+export default () => {
+  return new Promise(resolve => {
+    require.ensure([], () => {
+      require("./index.css")
+
+      resolve({
+        Demo: require("./index.js"),
+      })
+    })
+  })
+}

--- a/web_modules/LintWarnings/index.css
+++ b/web_modules/LintWarnings/index.css
@@ -14,11 +14,48 @@
 .location {
   flex: none;
   font-size: 0.75em;
+  font-weight: bold;
+  margin: 0 0.5em 0 0;
+  min-width: 3em;
+}
+
+.severity {
+  background: grey;
+  border-radius: 2px;
+  color: white;
+  flex: none;
+  font-size: 0.625em;
   margin: 0 1em 0 0;
-  min-width: 9em;
+  min-width: 5em;
+  text-align: center;
+}
+
+.errorSeverity {
+  composes: severity;
+  background: crimson;
+}
+
+.warningSeverity {
+  composes: severity;
+  background: gold;
 }
 
 .message {
-  font-size: 0.875em;
+  font-size: 0.75em;
   margin: 0;
+}
+
+.ruleLink {
+  color: crimson;
+
+  &:hover,
+  &:visited {
+    color: limegreen;
+  }
+}
+
+@media (width > 48em) {
+  .root {
+    font-size: 1.125rem;
+  }
 }

--- a/web_modules/LintWarnings/index.css
+++ b/web_modules/LintWarnings/index.css
@@ -1,0 +1,19 @@
+.root { /* placeholder */ }
+
+.result {
+  align-items: baseline;
+  display: flex;
+  font-family: "Oxygen Mono", monospace;
+}
+
+.location {
+  flex: none;
+  font-size: 0.75em;
+  margin: 0 1em 0 0;
+  min-width: 9em;
+}
+
+.message {
+  font-size: 0.875em;
+  margin: 0;
+}

--- a/web_modules/LintWarnings/index.css
+++ b/web_modules/LintWarnings/index.css
@@ -12,9 +12,9 @@
 }
 
 .location {
+  color: darkgray;
   flex: none;
   font-size: 0.75em;
-  font-weight: bold;
   margin: 0 0.5em 0 0;
   min-width: 3em;
 }
@@ -45,12 +45,16 @@
   margin: 0;
 }
 
-.ruleLink {
-  color: crimson;
+.ruleName {
+  color: darkgray;
+}
 
-  &:hover,
-  &:visited {
-    color: limegreen;
+.ruleLink {
+  color: darkgray;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
   }
 }
 

--- a/web_modules/LintWarnings/index.css
+++ b/web_modules/LintWarnings/index.css
@@ -1,9 +1,14 @@
-.root { /* placeholder */ }
+.root {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
 
 .result {
   align-items: baseline;
   display: flex;
   font-family: "Oxygen Mono", monospace;
+  margin-top: 0.2em;
 }
 
 .location {

--- a/web_modules/LintWarnings/index.js
+++ b/web_modules/LintWarnings/index.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react"
+import cx from "classnames"
 
 import styles from "./index.css"
 
@@ -12,11 +13,28 @@ export default class LintWarnings extends Component {
       <ul className={ styles.root }> {
         this.props.warnings.map(w => {
           const id = `${w.line}${w.column}${w.text}`
-          const location = `Line ${w.line} Col ${w.column}`
+          const location = `${w.line}:${w.column}`
+          const severityClassName = cx("", {
+            [styles.errorSeverity]: w.severity === "error",
+            [styles.warningSeverity]: w.severity === "warning",
+          })
+          const text = w.text.replace(`(${w.rule})`, "")
+          const url = `/user-guide/rules/${w.rule}/`
           return (
-            <li className={ styles.result } key={ id } >
-              <p className={ styles.location }> { location } </p>
-              <p className={ styles.message }>{ w.text }</p>
+            <li className={ styles.result } key={ id }>
+              <span className={ styles.location }> { location } </span>
+              <span className={ severityClassName }> { w.severity } </span>
+              <span className={ styles.message }>
+                { text }
+                { "(" }
+                  <a
+                    className={ styles.ruleLink }
+                    href={ url }
+                  >
+                    { w.rule }
+                  </a>
+                { ")" }
+              </span>
             </li>
           )
         })

--- a/web_modules/LintWarnings/index.js
+++ b/web_modules/LintWarnings/index.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react"
+
 import styles from "./index.css"
 
 export default class LintWarnings extends Component {
@@ -8,18 +9,18 @@ export default class LintWarnings extends Component {
 
   render() {
     return (
-      <div className={ styles.root }> {
+      <ul className={ styles.root }> {
         this.props.warnings.map(w => {
           const id = `${w.line}${w.column}${w.text}`
           const location = `Line ${w.line} Col ${w.column}`
           return (
-            <div className={ styles.result } key={ id } >
+            <li className={ styles.result } key={ id } >
               <p className={ styles.location }> { location } </p>
               <p className={ styles.message }>{ w.text }</p>
-            </div>
+            </li>
           )
         })
-      } </div>
+      } </ul>
     )
   }
 }

--- a/web_modules/LintWarnings/index.js
+++ b/web_modules/LintWarnings/index.js
@@ -26,14 +26,16 @@ export default class LintWarnings extends Component {
               <span className={ severityClassName }> { w.severity } </span>
               <span className={ styles.message }>
                 { text }
-                { "(" }
-                  <a
-                    className={ styles.ruleLink }
-                    href={ url }
-                  >
-                    { w.rule }
-                  </a>
-                { ")" }
+                <span className={ styles.ruleName }>
+                  { "(" }
+                    <a
+                      className={ styles.ruleLink }
+                      href={ url }
+                    >
+                      { w.rule }
+                    </a>
+                  { ")" }
+                </span>
               </span>
             </li>
           )

--- a/web_modules/LintWarnings/index.js
+++ b/web_modules/LintWarnings/index.js
@@ -1,0 +1,25 @@
+import React, { Component, PropTypes } from "react"
+import styles from "./index.css"
+
+export default class LintWarnings extends Component {
+  static propTypes = {
+    warnings: PropTypes.array.isRequired,
+  }
+
+  render() {
+    return (
+      <div className={ styles.root }> {
+        this.props.warnings.map(w => {
+          const id = `${w.line}${w.column}${w.text}`
+          const location = `Line ${w.line} Col ${w.column}`
+          return (
+            <div className={ styles.result } key={ id } >
+              <p className={ styles.location }> { location } </p>
+              <p className={ styles.message }>{ w.text }</p>
+            </div>
+          )
+        })
+      } </div>
+    )
+  }
+}

--- a/web_modules/Navigation/index.js
+++ b/web_modules/Navigation/index.js
@@ -43,6 +43,14 @@ export default class Navigation extends Component {
               { "Developer guide" }
             </Link>
           </li>
+          <li className={ styles.item }>
+            <Link
+              className={ styles.itemInner }
+              to="/demo/"
+            >
+              { "Demo" }
+            </Link>
+          </li>
         </ul>
       </nav>
     )

--- a/web_modules/app/routes.js
+++ b/web_modules/app/routes.js
@@ -5,6 +5,7 @@ import LayoutContainer from "../LayoutContainer"
 import PhenomicPageContainer from "phenomic/lib/PageContainer"
 
 import Page from "../layouts/Page"
+import DemoPage from "../layouts/DemoPage"
 import PageError from "../layouts/PageError"
 import PageLoading from "../layouts/PageLoading"
 
@@ -16,6 +17,7 @@ class PageContainer extends Component {
         { ...props }
         layouts={ {
           Page,
+          DemoPage,
           PageError,
           PageLoading,
         } }

--- a/web_modules/layouts/DemoPage/index.css
+++ b/web_modules/layouts/DemoPage/index.css
@@ -1,5 +1,5 @@
 .root {
-  margin: 0 auto 2rem auto;
+  margin: 0 auto 2rem;
   max-width: 100vw;
 }
 
@@ -9,6 +9,6 @@
   font-feature-settings: "liga" 1, "kern";
   font-size: 1em;
   line-height: 1.5;
-  margin: 1em auto 0 auto;
+  margin: 1em auto 0;
   text-align: center;
 }

--- a/web_modules/layouts/DemoPage/index.css
+++ b/web_modules/layouts/DemoPage/index.css
@@ -1,0 +1,5 @@
+.root {
+  margin: 0 auto 2rem auto;
+  max-width: 48rem;
+  padding: 0 1rem;
+}

--- a/web_modules/layouts/DemoPage/index.css
+++ b/web_modules/layouts/DemoPage/index.css
@@ -1,5 +1,14 @@
 .root {
   margin: 0 auto 2rem auto;
-  max-width: 48rem;
-  padding: 0 1rem;
+  max-width: 100vw;
+}
+
+.loadingMessage {
+  color: color(black a(87%));
+  font-family: "Alegreya Sans", sans-serif;
+  font-feature-settings: "liga" 1, "kern";
+  font-size: 1em;
+  line-height: 1.5;
+  margin: 1em auto 0 auto;
+  text-align: center;
 }

--- a/web_modules/layouts/DemoPage/index.js
+++ b/web_modules/layouts/DemoPage/index.js
@@ -3,15 +3,16 @@ import { PropTypes } from "react"
 import Helmet from "react-helmet"
 import invariant from "invariant"
 
+import Demo from "../../Demo"
+
 import styles from "./index.css"
 
-export default class Page extends Component {
+export default class DemoPage extends Component {
 
   static propTypes = {
     children: PropTypes.oneOfType([ PropTypes.array, PropTypes.object ]),
     __url: PropTypes.string.isRequired,
     head: PropTypes.object.isRequired,
-    body: PropTypes.string.isRequired,
   };
 
   static contextTypes = {
@@ -33,7 +34,6 @@ export default class Page extends Component {
 
     const {
       head,
-      body,
     } = this.props
 
     invariant(typeof head.title === "string", "Your page needs a title")
@@ -47,14 +47,9 @@ export default class Page extends Component {
           title={ title }
           meta={ meta }
         />
-        {
-          body &&
-          <div className={ styles.inner }
-            dangerouslySetInnerHTML={ { __html: body } }
-          />
-        }
-        <div dangerouslySetInnerHTML={ this.createMarkup() } />
+        <Demo />
         { this.props.children }
+        <div dangerouslySetInnerHTML={ this.createMarkup() } />
       </div>
     )
   }

--- a/web_modules/layouts/DemoPage/index.js
+++ b/web_modules/layouts/DemoPage/index.js
@@ -54,16 +54,6 @@ export default class DemoPage extends Component {
           <this.state.Demo.default /> :
           <p className={ styles.loadingMessage }>{ "Loading stylelint..." }</p>
         }
-        <link
-          rel={ "stylesheet" }
-          type={ "text/css" }
-          href={ "https://rawgit.com/codemirror/CodeMirror/master/lib/codemirror.css" } // eslint-disable-line max-len
-        />
-        <link
-          rel={ "stylesheet" }
-          type={ "text/css" }
-          href={ "https://rawgit.com/codemirror/CodeMirror/master/theme/eclipse.css" } // eslint-disable-line max-len
-        />
         { this.props.children }
       </div>
     )

--- a/web_modules/layouts/DemoPage/index.js
+++ b/web_modules/layouts/DemoPage/index.js
@@ -7,23 +7,23 @@ import styles from "./index.css"
 
 import DemoLoader from "../../Demo/loader.js"
 
-module.exports = class DemoPage extends Component {
+export default class DemoPage extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([ PropTypes.array, PropTypes.object ]),
+    __url: PropTypes.string.isRequired,
+    head: PropTypes.object.isRequired,
+  }
+
+  static contextTypes = {
+    metadata: PropTypes.object.isRequired,
+  }
+
   constructor(props) {
     super(props)
     this.state = {
       something: false,
     }
   }
-
-  static propTypes = {
-    children: PropTypes.oneOfType([ PropTypes.array, PropTypes.object ]),
-    __url: PropTypes.string.isRequired,
-    head: PropTypes.object.isRequired,
-  };
-
-  static contextTypes = {
-    metadata: PropTypes.object.isRequired,
-  };
 
   componentWillMount() {
     // Only load Demo when this layout will be rendered

--- a/web_modules/layouts/DemoPage/index.js
+++ b/web_modules/layouts/DemoPage/index.js
@@ -3,11 +3,17 @@ import { PropTypes } from "react"
 import Helmet from "react-helmet"
 import invariant from "invariant"
 
-import Demo from "../../Demo"
-
 import styles from "./index.css"
 
-export default class DemoPage extends Component {
+import DemoLoader from "../../Demo/loader.js"
+
+module.exports = class DemoPage extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      something: false,
+    }
+  }
 
   static propTypes = {
     children: PropTypes.oneOfType([ PropTypes.array, PropTypes.object ]),
@@ -19,11 +25,11 @@ export default class DemoPage extends Component {
     metadata: PropTypes.object.isRequired,
   };
 
-  createMarkup() {
-    const src = "https://rawgit.com/m-allanson/stylelint-browser-bundle/7ab3e6f/dist/stylelint-browser-bundle.js" // eslint-disable-line max-len
-    return {
-      __html: `<script src="${src}"></script>`,
-    }
+  componentWillMount() {
+    // Only load Demo when this layout will be rendered
+    DemoLoader().then(({ Demo }) => {
+      this.setState({ Demo })
+    })
   }
 
   render() {
@@ -47,9 +53,21 @@ export default class DemoPage extends Component {
           title={ title }
           meta={ meta }
         />
-        <Demo />
+        { this.state.Demo ?
+          <this.state.Demo.default /> :
+          <p className={ styles.loadingMessage }>{ "Loading stylelint..." }</p>
+        }
+        <link
+          rel={ "stylesheet" }
+          type={ "text/css" }
+          href={ "https://rawgit.com/codemirror/CodeMirror/master/lib/codemirror.css" } // eslint-disable-line max-len
+        />
+        <link
+          rel={ "stylesheet" }
+          type={ "text/css" }
+          href={ "https://rawgit.com/codemirror/CodeMirror/master/theme/eclipse.css" } // eslint-disable-line max-len
+        />
         { this.props.children }
-        <div dangerouslySetInnerHTML={ this.createMarkup() } />
       </div>
     )
   }

--- a/web_modules/layouts/DemoPage/index.js
+++ b/web_modules/layouts/DemoPage/index.js
@@ -1,5 +1,4 @@
-import React, { Component } from "react"
-import { PropTypes } from "react"
+import React, { Component, PropTypes } from "react"
 import Helmet from "react-helmet"
 import invariant from "invariant"
 
@@ -20,9 +19,7 @@ export default class DemoPage extends Component {
 
   constructor(props) {
     super(props)
-    this.state = {
-      something: false,
-    }
+    this.state = {}
   }
 
   componentWillMount() {

--- a/web_modules/layouts/Page/index.css
+++ b/web_modules/layouts/Page/index.css
@@ -75,7 +75,8 @@
   & a {
     color: crimson;
 
-    &:hover {
+    &:hover,
+    &:visited {
       color: limegreen;
     }
   }

--- a/web_modules/layouts/Page/index.js
+++ b/web_modules/layouts/Page/index.js
@@ -18,13 +18,6 @@ export default class Page extends Component {
     metadata: PropTypes.object.isRequired,
   };
 
-  createMarkup() {
-    const src = "https://rawgit.com/m-allanson/stylelint-browser-bundle/7ab3e6f/dist/stylelint-browser-bundle.js" // eslint-disable-line max-len
-    return {
-      __html: `<script src="${src}"></script>`,
-    }
-  }
-
   render() {
 
     const {
@@ -53,7 +46,6 @@ export default class Page extends Component {
             dangerouslySetInnerHTML={ { __html: body } }
           />
         }
-        <div dangerouslySetInnerHTML={ this.createMarkup() } />
         { this.props.children }
       </div>
     )


### PR DESCRIPTION
This is not ready to merge yet.

You can test this branch by running `npm start` and browsing to `http://0.0.0.0:3000/demo/`.

## Approach

Syntax highlighting and line numbers are included thanks to [CodeMirror](https://codemirror.net/)

I've created a [standalone stylelint browser bundle](https://github.com/m-allanson/stylelint-browser-bundle.git) which is imported by the `Demo` component.

A [loader](https://github.com/stylelint/stylelint.io/blob/c4fa9b926a20bbf4e72c9aa463dacc67886ac1f6/web_modules/Demo/loader.js) is used to tell webpack to create a second js chunk which can be loaded on demand. This chunk is requested when a user hits the `/demo` route.

## Problems

This approach broadly works, but there are some areas that need improvement:

- ~~The build task now takes 10 - 15 minutes (on my machine)~~
- The demo js file is 1.7MB (after minification) 
- There are no tests
- ~~The CodeMirror CSS is being loaded with link tags pointing to `https://rawgit.com`~~
- ~~It relies on my standalone stylelint browser bundle~~

I'll be away for the next few days, so wanted to get this online for people to comment on. Feedback is very welcome, as always :)

Refs #2 