### PR TITLE
WIP #13

### DIFF
--- a/scripts/process-docs-lib/processFrontMatter.js
+++ b/scripts/process-docs-lib/processFrontMatter.js
@@ -6,6 +6,7 @@ export default function(paths, properties) {
   paths.forEach(function(path) {
     const contents = fs.readFileSync(path, "utf-8")
     const frontMatter = buildFrontMatter(path, contents, properties)
+
     const newContents = prependFrontMatter(frontMatter, contents)
     fs.writeFileSync(path, newContents)
   })

--- a/web_modules/layouts/Page/index.css
+++ b/web_modules/layouts/Page/index.css
@@ -140,6 +140,10 @@
     height: auto;
     max-width: 100%;
   }
+
+  & p[data-example-warning] + pre > code {
+    background: red;
+  }
 }
 
 @media (width > 48em) {

--- a/web_modules/layouts/Page/index.css
+++ b/web_modules/layouts/Page/index.css
@@ -95,6 +95,14 @@
   & pre {
     position: relative;
 
+    &:global(.valid-pattern) > code {
+      background: color(green a(20%));
+    }
+
+    &:global(.invalid-pattern) > code {
+      background: color(red a(20%));
+    }
+
     &::after,
     &::before {
       background: color(whitesmoke a(50%));
@@ -139,10 +147,6 @@
   & img {
     height: auto;
     max-width: 100%;
-  }
-
-  & p[data-example-warning] + pre > code {
-    background: red;
   }
 }
 

--- a/web_modules/layouts/Page/index.css
+++ b/web_modules/layouts/Page/index.css
@@ -95,19 +95,12 @@
   & pre {
     position: relative;
 
-    &:global(.valid-pattern) > code {
-      background: color(green a(20%));
-    }
-
-    &:global(.invalid-pattern) > code {
-      background: color(red a(20%));
-    }
-
     &::after,
     &::before {
-      background: color(whitesmoke a(50%));
+      background: whitesmoke;
       bottom: 0;
       content: "";
+      opacity: 0.5;
       position: absolute;
       right: 0;
       top: 0;
@@ -115,7 +108,8 @@
     }
 
     &::before {
-      background: color(whitesmoke a(75%));
+      background: whitesmoke;
+      opacity: 0.75;
       width: 0.5em;
     }
 
@@ -124,6 +118,22 @@
       line-height: 1.5;
       overflow: auto;
       padding: 1em 1.5em 1em 1em;
+    }
+
+    &:global(.valid-pattern) {
+      & > code,
+      &::before,
+      &::after {
+        background: #eef7ee;
+      }
+    }
+
+    &:global(.invalid-pattern) {
+      & > code,
+      &::before,
+      &::after {
+        background: #fee;
+      }
     }
   }
 

--- a/web_modules/layouts/Page/index.js
+++ b/web_modules/layouts/Page/index.js
@@ -6,6 +6,13 @@ import { BodyContainer } from "phenomic"
 
 import styles from "./index.css"
 
+function enhanceCodeBlocks(contents) {
+  return contents.replace(
+    /<p>The following patterns are considered warnings:<\/p>/,
+    "<p data-example-warning>The following patterns are considered warnings:<\/p>",
+  )
+}
+
 export default class Page extends Component {
 
   static propTypes = {
@@ -41,7 +48,7 @@ export default class Page extends Component {
           title={ title }
           meta={ meta }
         />
-        <BodyContainer>{ body }</BodyContainer>
+        <BodyContainer>{ enhanceCodeBlocks(body) }</BodyContainer>
         { this.props.children }
       </div>
     )

--- a/web_modules/layouts/Page/index.js
+++ b/web_modules/layouts/Page/index.js
@@ -76,6 +76,10 @@ export default class Page extends Component {
     applyTransformsToContent(this._bodyContent)
   }
 
+  componentDidUpdate() {
+    applyTransformsToContent(this._bodyContent)
+  }
+
   render() {
 
     const {

--- a/web_modules/layouts/Page/index.js
+++ b/web_modules/layouts/Page/index.js
@@ -6,6 +6,11 @@ import { BodyContainer } from "phenomic"
 
 import styles from "./index.css"
 
+const triggers = {
+  validPattern: "The following patterns are not considered warnings:",
+  invalidPattern: "The following patterns are considered warnings:",
+}
+
 function applyTransformsToContent(bodyContent) {
   let invalidPatternFlag = false
   let validPatternFlag = false
@@ -15,13 +20,13 @@ function applyTransformsToContent(bodyContent) {
       return
     }
 
-    if (nodeIsValidPatternTrigger(node)) {
+    if (nodeIsPatternTrigger(node, triggers.validPattern)) {
       invalidPatternFlag = false
       validPatternFlag = true
       node.classList.add("valid-pattern")
     }
 
-    if (nodeIsInvalidPatternTrigger(node)) {
+    if (nodeIsPatternTrigger(node, triggers.invalidPattern)) {
       invalidPatternFlag = true
       validPatternFlag = false
       node.classList.add("invalid-pattern")
@@ -36,13 +41,7 @@ function applyTransformsToContent(bodyContent) {
   })
 }
 
-function nodeIsValidPatternTrigger(node) {
-  const triggerText = "The following patterns are not considered warnings:"
-  return node.tagName === "P" && node.innerText === triggerText
-}
-
-function nodeIsInvalidPatternTrigger(node) {
-  const triggerText = "The following patterns are considered warnings:"
+function nodeIsPatternTrigger(node, triggerText) {
   return node.tagName === "P" && node.innerText === triggerText
 }
 
@@ -93,6 +92,7 @@ export default class Page extends Component {
     const title = head.title + " - " + pkg.name
     const meta = []
 
+    /* eslint-disable react/jsx-no-bind, brace-style */
     return (
       <div className={ styles.root }>
         <Helmet
@@ -108,5 +108,6 @@ export default class Page extends Component {
         { this.props.children }
       </div>
     )
+    /* eslint-enable react/jsx-no-bind, brace-style */
   }
 }

--- a/web_modules/layouts/Page/index.js
+++ b/web_modules/layouts/Page/index.js
@@ -6,15 +6,62 @@ import { BodyContainer } from "phenomic"
 
 import styles from "./index.css"
 
-function enhanceCodeBlocks(contents) {
-  return contents.replace(
-    /<p>The following patterns are considered warnings:<\/p>/,
-    "<p data-example-warning>The following patterns are considered warnings:<\/p>",
-  )
+function applyTransformsToContent(bodyContent) {
+  let invalidPatternFlag = false
+  let validPatternFlag = false
+
+  bodyContent.childNodes.forEach((node) => {
+    if (!node.classList) {
+      return
+    }
+
+    if (nodeIsValidPatternTrigger(node)) {
+      invalidPatternFlag = false
+      validPatternFlag = true
+      node.classList.add("valid-pattern")
+    }
+
+    if (nodeIsInvalidPatternTrigger(node)) {
+      invalidPatternFlag = true
+      validPatternFlag = false
+      node.classList.add("invalid-pattern")
+    }
+
+    if (nodeIsTriggerReset(node)) {
+      invalidPatternFlag = false
+      validPatternFlag = false
+    }
+
+    appendFlagsToPre(node, validPatternFlag, invalidPatternFlag)
+  })
+}
+
+function nodeIsValidPatternTrigger(node) {
+  const triggerText = "The following patterns are not considered warnings:"
+  return node.tagName === "P" && node.innerText === triggerText
+}
+
+function nodeIsInvalidPatternTrigger(node) {
+  const triggerText = "The following patterns are considered warnings:"
+  return node.tagName === "P" && node.innerText === triggerText
+}
+
+function nodeIsTriggerReset(node) {
+  const resetTriggers = [ "H1", "H2", "H3", "H4", "H5", "H6" ]
+
+  if (resetTriggers.indexOf(node.tagName) !== -1) {
+    return true
+  }
+}
+
+function appendFlagsToPre(node, validFlag, invalidFlag) {
+  if (node.tagName === "PRE") {
+    validFlag && node.classList.add("valid-pattern")
+    invalidFlag && node.classList.add("invalid-pattern")
+  }
 }
 
 export default class Page extends Component {
-
   static propTypes = {
     children: PropTypes.oneOfType([ PropTypes.array, PropTypes.object ]),
     __url: PropTypes.string.isRequired,
@@ -25,6 +72,10 @@ export default class Page extends Component {
   static contextTypes = {
     metadata: PropTypes.object.isRequired,
   };
+
+  componentDidMount() {
+    applyTransformsToContent(this._bodyContent)
+  }
 
   render() {
 
@@ -48,7 +99,12 @@ export default class Page extends Component {
           title={ title }
           meta={ meta }
         />
-        <BodyContainer>{ enhanceCodeBlocks(body) }</BodyContainer>
+        <BodyContainer>{
+          <div
+            ref={ (c) => { this._bodyContent = c } }
+            dangerouslySetInnerHTML={ { __html: body } }
+          />
+        }</BodyContainer>
         { this.props.children }
       </div>
     )


### PR DESCRIPTION
### WIP

I've looked at the build setup and tried to add some sort of hook to the prerendered body string in [`Page/index`](https://github.com/stylelint/stylelint.io/blob/master/web_modules/layouts/Page/index.js)

Unfortunately the only thing I've managed to do is a simple replace of `/<p>The following patterns are considered warnings:<\/p>/`. But this isn't feasible due to two reasons
- The warning/correct naming isn't always as in my example
- The general sibling selector can't be used and the adjacent sibling selector only styles the next pre element

I will examine some other possibilities but at the moment I haven't got a bright solution...