### PR TITLE
Tighten body margin on narrow viewports

### DIFF
--- a/src/layouts/Page/index.css
+++ b/src/layouts/Page/index.css
@@ -6,7 +6,7 @@
 
 .body {
   font-size: 0.875rem;
-  margin: 2rem auto;
+  margin: 1.5rem auto;
   max-width: 57.5rem;
   padding: 0 1rem;
   width: 100%;
@@ -174,6 +174,8 @@
 @media (width > 54em) {
   .body {
     font-size: 1rem;
+    margin-bottom: 2rem;
+    margin-top: 2rem;
     padding: 0 2rem;
 
     & ul,


### PR DESCRIPTION
From this:

<img width="398" alt="screen shot 2016-11-25 at 22 24 11" src="https://cloud.githubusercontent.com/assets/808227/20636066/16962c3c-b35e-11e6-9773-e4fa57439998.png">

--- 

To this:

<img width="440" alt="screen shot 2016-11-25 at 22 56 42" src="https://cloud.githubusercontent.com/assets/808227/20636305/7a1d5cea-b362-11e6-9fdb-56723ec9a932.png">

---

As a bit too much wasted vertical real-estate on small viewports.