### PR TITLE
Use prop-types library instead of React internal PropTypes (#50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "postcss-loader": "^1.1.1",
     "postcss-reporter": "^3.0.0",
     "prettier": "~1.9.2",
+    "prop-types": "^15.6.0",
     "raw-loader": "^0.5.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import Container from "./components/Container";
 import Content from "./components/Content";

--- a/src/components/Container/index.js
+++ b/src/components/Container/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import styles from "./index.css";
 

--- a/src/components/Content/index.js
+++ b/src/components/Content/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import styles from "./index.css";
 

--- a/src/components/DefaultHeadMeta/index.js
+++ b/src/components/DefaultHeadMeta/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import Helmet from "react-helmet";
 
 import favicon from "./favicon.ico";
@@ -54,8 +55,8 @@ const DefaultHeadMeta = (props, { metadata: { pkg } }) => (
 );
 
 DefaultHeadMeta.propTypes = {
-  meta: React.PropTypes.arrayOf(React.PropTypes.object),
-  scripts: React.PropTypes.arrayOf(React.PropTypes.object)
+  meta: PropTypes.arrayOf(PropTypes.object),
+  scripts: PropTypes.arrayOf(PropTypes.object)
 };
 
 DefaultHeadMeta.contextTypes = {

--- a/src/components/GoogleAnalyticsTracker/index.js
+++ b/src/components/GoogleAnalyticsTracker/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
 import ga from "react-google-analytics";
 
 const GoogleAnalyticsInitiailizer = ga.Initializer;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { Link } from "phenomic";
 import Svg from "react-svg-inline";
 

--- a/src/layouts/Page/index.js
+++ b/src/layouts/Page/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import Helmet from "react-helmet";
 import warning from "warning";
 import { BodyContainer, joinUri } from "phenomic";

--- a/src/layouts/PageError/index.js
+++ b/src/layouts/PageError/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import Page from "../Page";
 

--- a/src/layouts/RulePage/index.js
+++ b/src/layouts/RulePage/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { Link } from "phenomic";
 
 import Page from "../Page";


### PR DESCRIPTION
https://github.com/stylelint/stylelint.io/issues/50

Unfortunately, warnings are still here, because Phenomic uses deprecated things. Well, at least our code doesn't use them. New Phenomic version still in alpha.