### PR TITLE
Visual fixes

### DIFF
--- a/src/index.global.css
+++ b/src/index.global.css
@@ -8,6 +8,7 @@
 html {
   box-sizing: border-box;
   min-height: 100%;
+  overflow-y: scroll;
 }
 
 *,

--- a/src/layouts/DemoPage/index.css
+++ b/src/layouts/DemoPage/index.css
@@ -1,3 +1,4 @@
 .demoPage {
   height: 100vh;
+  height: calc(100vh - 64px - 80px); /* Remove header and footer height */
 }

--- a/src/layouts/Page/index.css
+++ b/src/layouts/Page/index.css
@@ -95,7 +95,7 @@
 
   /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
   & :--headings {
-    color: color(black a(68%));
+    color: #333;
     flex-direction: row-reverse;
     font-weight: 600;
     line-height: 1.25;


### PR DESCRIPTION
Make headings easier to read by improving contrast (make them darker).

Fix jumping content between navigation, if one of the pages doesn't have a scrollbar. Issue video: http://take.ms/mjy69

Remove double scrolling for demo page. There is still the second scrollbar, but it doesn't scroll page now.

![image](https://user-images.githubusercontent.com/654597/34411600-f60e1ee4-ebd7-11e7-8741-b28b6de1e99f.png)

