### PR TITLE
Add Table of Contents generation (#42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier:check": "prettier '**/*.js' --list-different",
     "prettier:fix": "prettier '**/*.js' --write",
     "pretest": "npm run lint",
-    "test": "npm run build",
+    "test": "jest && npm run build",
     "precopy": "rimraf content dist",
     "copy": "node ./scripts/copy-stylelint-docs",
     "prestart": "npm run copy",
@@ -23,7 +23,8 @@
     "prebuild": "npm run copy",
     "build": "phenomic build",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -t -d dist -r git@github.com:stylelint/stylelint.github.io.git -b master"
+    "deploy": "gh-pages -t -d dist -r git@github.com:stylelint/stylelint.github.io.git -b master",
+    "watch": "jest --watch"
   },
   "phenomic": {
     "assets": false,
@@ -83,7 +84,11 @@
   },
   "eslintConfig": {
     "root": true,
-    "extends": "./node_modules/phenomic/lib/eslint-config-recommended/index.js"
+    "extends": "./node_modules/phenomic/lib/eslint-config-recommended/index.js",
+    "env": {
+      "node": true,
+      "jest": true
+    }
   },
   "stylelint": {
     "extends": "stylelint-config-standard",
@@ -125,6 +130,9 @@
       "git add"
     ]
   },
+  "jest": {
+    "testEnvironment": "node"
+  },
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-core": "^6.14.0",
@@ -147,6 +155,7 @@
     "gh-pages": "^1.1.0",
     "history": "^2.0.0",
     "husky": "^0.14.3",
+    "jest": "^22.0.4",
     "lint-staged": "^6.0.0",
     "mdast-util-to-string": "^1.0.2",
     "npm-run-all": "^4.0.2",
@@ -168,6 +177,7 @@
     "react-svg-inline": "^2.0.1",
     "react-topbar-progress-indicator": "^2.0.0",
     "redux": "^3.6.0",
+    "remark-toc": "^3.1.0",
     "rimraf": "^2.5.4",
     "style-loader": "^0.19.1",
     "stylelint": "^8.4.0",

--- a/plugins/loader-plugin-markdown-transform-body-property-to-html/index.js
+++ b/plugins/loader-plugin-markdown-transform-body-property-to-html/index.js
@@ -1,7 +1,7 @@
 /**
  * Adaption of phenomic's default markdown plugin.
  *
- * Calls two custom remark plugins
+ * Calls three custom remark plugins
  */
 
 import remark from "remark";
@@ -10,14 +10,16 @@ import autoLinkHeadings from "remark-autolink-headings";
 import highlight from "remark-highlight.js";
 import html from "remark-html";
 import stylelintPatternValidity from "../remark-stylelint-pattern-validity";
+import stylelintToc from "../remark-stylelint-toc";
 import stylelintUrl from "../remark-stylelint-url";
 
-function mdify(text) {
+function mdify(text, layout) {
   return (
     remark()
-      // Two custom stylelint remark plugins
+      // Three custom stylelint remark plugins
       .use(stylelintUrl)
       .use(stylelintPatternValidity)
+      .use(stylelintToc, { layout })
 
       // https://github.com/wooorm/remark-slug
       .use(slug)
@@ -50,6 +52,6 @@ function mdify(text) {
 export default ({ result }) => {
   return {
     ...result,
-    body: mdify(result.body)
+    body: mdify(result.body, result.head.layout)
   };
 };

--- a/plugins/remark-stylelint-toc/__tests__/__snapshots__/index.test.js.snap
+++ b/plugins/remark-stylelint-toc/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`don't generate TOC 1`] = `
+"bbb
+
+## Options
+
+### \`\\"always\\"\`
+
+ccc
+
+### \`\\"never\\"\`
+
+ddd
+
+## Optional secondary options
+
+### \`except: [\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"]\`
+
+#### \`\\"after-comment\\"\`
+
+eee
+
+#### \`\\"after-declaration\\"\`
+
+fff
+"
+`;
+
+exports[`generate on a any page if comment exist 1`] = `
+"# aaa
+
+-   [ab](#ab)
+
+-   [Options](#options)
+
+    -   [\\"always\\"](#always)
+    -   [\\"never\\"](#never)
+
+-   [Optional secondary options](#optional-secondary-options)
+
+    -   [except: \\\\[\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"\\\\]](#except-after-comment-after-declaration-first-nested)
+
+        -   [\\"after-comment\\"](#after-comment)
+        -   [\\"after-declaration\\"](#after-declaration)
+
+## ab
+
+bbb
+
+## Options
+
+### \`\\"always\\"\`
+
+ccc
+
+### \`\\"never\\"\`
+
+ddd
+
+## Optional secondary options
+
+### \`except: [\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"]\`
+
+#### \`\\"after-comment\\"\`
+
+eee
+
+#### \`\\"after-declaration\\"\`
+
+fff
+"
+`;
+
+exports[`generate on a rule page before Options 1`] = `
+"bbb
+
+-   [Options](#options)
+
+    -   [\\"always\\"](#always)
+    -   [\\"never\\"](#never)
+
+-   [Optional secondary options](#optional-secondary-options)
+
+    -   [except: \\\\[\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"\\\\]](#except-after-comment-after-declaration-first-nested)
+
+        -   [\\"after-comment\\"](#after-comment)
+        -   [\\"after-declaration\\"](#after-declaration)
+
+## Options
+
+### \`\\"always\\"\`
+
+ccc
+
+### \`\\"never\\"\`
+
+ddd
+
+## Optional secondary options
+
+### \`except: [\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"]\`
+
+#### \`\\"after-comment\\"\`
+
+eee
+
+#### \`\\"after-declaration\\"\`
+
+fff
+"
+`;
+
+exports[`generate on a rule page if comment exist 1`] = `
+"# aaa
+
+-   [ab](#ab)
+
+-   [Options](#options)
+
+    -   [\\"always\\"](#always)
+    -   [\\"never\\"](#never)
+
+-   [Optional secondary options](#optional-secondary-options)
+
+    -   [except: \\\\[\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"\\\\]](#except-after-comment-after-declaration-first-nested)
+
+        -   [\\"after-comment\\"](#after-comment)
+        -   [\\"after-declaration\\"](#after-declaration)
+
+## ab
+
+bbb
+
+## Options
+
+### \`\\"always\\"\`
+
+ccc
+
+### \`\\"never\\"\`
+
+ddd
+
+## Optional secondary options
+
+### \`except: [\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"]\`
+
+#### \`\\"after-comment\\"\`
+
+eee
+
+#### \`\\"after-declaration\\"\`
+
+fff
+"
+`;

--- a/plugins/remark-stylelint-toc/__tests__/__snapshots__/index.test.js.snap
+++ b/plugins/remark-stylelint-toc/__tests__/__snapshots__/index.test.js.snap
@@ -27,7 +27,77 @@ fff
 "
 `;
 
-exports[`generate on a any page if comment exist 1`] = `
+exports[`don't generate if TOC is only one level deep in a rule page 1`] = `
+"bbb
+
+## Options
+
+### \`\\"always\\"\`
+
+ccc
+"
+`;
+
+exports[`generate on a rule page before Options 1`] = `
+"bbb
+
+-   [Options](#options)
+
+    -   [\\"always\\"](#always)
+    -   [\\"never\\"](#never)
+
+-   [Optional secondary options](#optional-secondary-options)
+
+    -   [except: \\\\[\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"\\\\]](#except-after-comment-after-declaration-first-nested)
+
+        -   [\\"after-comment\\"](#after-comment)
+        -   [\\"after-declaration\\"](#after-declaration)
+
+## Options
+
+### \`\\"always\\"\`
+
+ccc
+
+### \`\\"never\\"\`
+
+ddd
+
+## Optional secondary options
+
+### \`except: [\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"]\`
+
+#### \`\\"after-comment\\"\`
+
+eee
+
+#### \`\\"after-declaration\\"\`
+
+fff
+"
+`;
+
+exports[`generate on a rule page if Options has more than one section 1`] = `
+"bbb
+
+-   [Options](#options)
+
+    -   [\\"always\\"](#always)
+    -   [\\"never\\"](#never)
+
+## Options
+
+### \`\\"always\\"\`
+
+ccc
+
+### \`\\"never\\"\`
+
+ddd
+"
+`;
+
+exports[`generate on a rule page if comment exist 1`] = `
 "# aaa
 
 -   [ab](#ab)
@@ -72,46 +142,7 @@ fff
 "
 `;
 
-exports[`generate on a rule page before Options 1`] = `
-"bbb
-
--   [Options](#options)
-
-    -   [\\"always\\"](#always)
-    -   [\\"never\\"](#never)
-
--   [Optional secondary options](#optional-secondary-options)
-
-    -   [except: \\\\[\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"\\\\]](#except-after-comment-after-declaration-first-nested)
-
-        -   [\\"after-comment\\"](#after-comment)
-        -   [\\"after-declaration\\"](#after-declaration)
-
-## Options
-
-### \`\\"always\\"\`
-
-ccc
-
-### \`\\"never\\"\`
-
-ddd
-
-## Optional secondary options
-
-### \`except: [\\"after-comment\\", \\"after-declaration\\", \\"first-nested\\"]\`
-
-#### \`\\"after-comment\\"\`
-
-eee
-
-#### \`\\"after-declaration\\"\`
-
-fff
-"
-`;
-
-exports[`generate on a rule page if comment exist 1`] = `
+exports[`generate on any page if comment exist 1`] = `
 "# aaa
 
 -   [ab](#ab)

--- a/plugins/remark-stylelint-toc/__tests__/index.test.js
+++ b/plugins/remark-stylelint-toc/__tests__/index.test.js
@@ -25,6 +25,15 @@ eee
 
 fff`;
 
+const contentShort = `bbb
+
+## Options
+
+### \`"always"\`
+
+ccc
+`;
+
 test(`don't generate TOC`, () => {
   expect(run(content)).toMatchSnapshot();
 });
@@ -39,8 +48,18 @@ test(`generate on a rule page if comment exist`, () => {
   ).toMatchSnapshot();
 });
 
-test(`generate on a any page if comment exist`, () => {
+test(`generate on any page if comment exist`, () => {
   expect(run(`# aaa\n\n<!-- TOC -->\n\n## ab\n\n${content}`)).toMatchSnapshot();
+});
+
+test(`don't generate if TOC is only one level deep in a rule page`, () => {
+  expect(run(contentShort, "RulePage")).toMatchSnapshot();
+});
+
+test(`generate on a rule page if Options has more than one section`, () => {
+  expect(
+    run(`${contentShort}\n### \`"never"\`\n\nddd`, "RulePage")
+  ).toMatchSnapshot();
 });
 
 function run(content, layout) {

--- a/plugins/remark-stylelint-toc/__tests__/index.test.js
+++ b/plugins/remark-stylelint-toc/__tests__/index.test.js
@@ -1,0 +1,50 @@
+import remark from "remark";
+import stylelintToc from "../";
+
+const content = `bbb
+
+## Options
+
+### \`"always"\`
+
+ccc
+
+### \`"never"\`
+
+ddd
+
+## Optional secondary options
+
+### \`except: ["after-comment", "after-declaration", "first-nested"]\`
+
+#### \`"after-comment"\`
+
+eee
+
+#### \`"after-declaration"\`
+
+fff`;
+
+test(`don't generate TOC`, () => {
+  expect(run(content)).toMatchSnapshot();
+});
+
+test(`generate on a rule page before Options`, () => {
+  expect(run(content, "RulePage")).toMatchSnapshot();
+});
+
+test(`generate on a rule page if comment exist`, () => {
+  expect(
+    run(`# aaa\n\n<!-- TOC -->\n\n## ab\n\n${content}`, "RulePage")
+  ).toMatchSnapshot();
+});
+
+test(`generate on a any page if comment exist`, () => {
+  expect(run(`# aaa\n\n<!-- TOC -->\n\n## ab\n\n${content}`)).toMatchSnapshot();
+});
+
+function run(content, layout) {
+  return remark()
+    .use(stylelintToc, { layout })
+    .process(content).contents;
+}

--- a/plugins/remark-stylelint-toc/index.js
+++ b/plugins/remark-stylelint-toc/index.js
@@ -1,0 +1,89 @@
+import _ from "lodash";
+import tocPlugin from "remark-toc";
+import visit from "unist-util-visit";
+
+export default function stylelintToc(processor, { layout }) {
+  return function transformer() {
+    const heading = "Table of Contents";
+
+    // Using sequence of plugins, because otherwise their run order is random
+    processor
+      .use(addTocHeading, { heading, layout })
+      .use(tocPlugin, { heading })
+      .use(removeTocHeading, { heading });
+  };
+}
+
+// Remark plugin for adding TOC heading
+function addTocHeading(processor, options) {
+  return function(tree) {
+    const tocComment = "<!-- TOC -->";
+    const tocHeading = {
+      type: "heading",
+      depth: 2,
+      children: [
+        {
+          type: "text",
+          value: options.heading
+        }
+      ]
+    };
+    let tocComments = 0;
+
+    // Search for TOC comment
+    visit(tree, "html", node => {
+      if (node.value === tocComment) {
+        tocComments += 1;
+      }
+    });
+
+    // Don't do anything if there more than one comment
+    if (tocComments > 1) {
+      return;
+    }
+
+    // Replace TOC comment with TOC heading
+    if (tocComments === 1) {
+      visit(tree, "html", (node, index, parent) => {
+        if (node.value === tocComment) {
+          parent.children = [
+            ...parent.children.slice(0, index),
+            tocHeading,
+            ...parent.children.slice(index + 1)
+          ];
+        }
+      });
+    }
+
+    // Create TOC heading on a rule page before Options heading
+    if (tocComments === 0 && options.layout === "RulePage") {
+      visit(tree, "heading", (node, index, parent) => {
+        if (searchHeading(node, "Options", tree)) {
+          parent.children = [
+            ...parent.children.slice(0, index),
+            tocHeading,
+            ...parent.children.slice(index)
+          ];
+        }
+      });
+    }
+  };
+}
+
+// Remark plugin for removing TOC heading
+function removeTocHeading(processor, options) {
+  return function(tree) {
+    visit(tree, "heading", (node, index, parent) => {
+      if (searchHeading(node, options.heading)) {
+        parent.children = [
+          ...parent.children.slice(0, index),
+          ...parent.children.slice(index + 1)
+        ];
+      }
+    });
+  };
+}
+
+function searchHeading(node, title) {
+  return Boolean(_.find(node.children, { type: "text", value: title }));
+}


### PR DESCRIPTION
Generate Table of Contents for rules and other pages. #42

For rules, TOC generated automatically and inserted before “Options” heading.

For other pages we need to add `<!-- TOC -->` in markdown in `stylelint` repository. One caveat. This comment should be right before any `##` heading. `remark-toc` removes everything after TOC heading, and before next heading. So if TOC heading is right before another heading, then nothing will be deleted. I could add a workaround for this case, but I don't think we'll face it. Table of Contents usually right before headings.

I'll create a PR in the main repository with TOC after this PR merged.

Non-rule page if `<!-- TOC -->` is in markdown:

![image](https://user-images.githubusercontent.com/654597/34458139-388e8b46-edc7-11e7-9d89-bc121798130a.png)


Rule page:

![image](https://user-images.githubusercontent.com/654597/34458142-3c3fc8b8-edc7-11e7-9413-66207ffaa297.png)


I have concerns about rules, where there is `true` option only:

![image](https://user-images.githubusercontent.com/654597/34458143-4381475a-edc7-11e7-8dd7-79e9fc33c91b.png)


Shall we hide TOC in this case, as it useless? Shall we keep it anyway, as it consistent with other pages? I think it's better to hide it, but I need more opinions.

Also, there is one thing I don't like. Code in headings transformed into regular text. This is a problem with `remark-toc` dependency (the one which generates TOC).

This:

```md
## `ignore: ["after-comment", "inside-single-line-block"]`
```

Transformed into:

```md
- [ignore: \["after-comment", "inside-single-line-block"\]](#ignore-after-comment-inside-single-line-block)
```

This is not cool. I'm going investigate if the newer version of `remark-toc` preserve code formatting. Otherwise, I'll create a ticket to `remark-toc` to fix this problem (or fix it myself). But we need to use newer `remark` to use latest `remark-toc`.

Had to use older `remark-toc`, because we use old `remark`. We use `remark` which is not in our dependencies (it's a dependency of  Phenomic). Probably should use `remark` and its plugins as our dependencies. But it's a task for other PR.

Added Jest, because wanted new plugin to be tested.