### PR TITLE
Allow to have TOC heading before any level heading

### DIFF
--- a/plugins/remark-stylelint-toc/__tests__/__snapshots__/index.test.js.snap
+++ b/plugins/remark-stylelint-toc/__tests__/__snapshots__/index.test.js.snap
@@ -38,6 +38,32 @@ ccc
 "
 `;
 
+exports[`generate if TOC comment before h2 heading 1`] = `
+"bbb
+
+-   [ccc](#ccc)
+
+## ccc
+
+ddd
+    
+"
+`;
+
+exports[`generate if TOC comment before h3 heading 1`] = `
+"bbb
+
+## ccc
+
+-   [ddd](#ddd)
+
+### ddd
+
+eee
+    
+"
+`;
+
 exports[`generate on a rule page before Options 1`] = `
 "bbb
 

--- a/plugins/remark-stylelint-toc/__tests__/index.test.js
+++ b/plugins/remark-stylelint-toc/__tests__/index.test.js
@@ -62,6 +62,36 @@ test(`generate on a rule page if Options has more than one section`, () => {
   ).toMatchSnapshot();
 });
 
+test(`generate if TOC comment before h2 heading`, () => {
+  expect(
+    run(`
+bbb
+
+<!-- TOC -->
+
+## ccc
+
+ddd
+    `)
+  ).toMatchSnapshot();
+});
+
+test(`generate if TOC comment before h3 heading`, () => {
+  expect(
+    run(`
+bbb
+
+## ccc
+
+<!-- TOC -->
+
+### ddd
+
+eee
+    `)
+  ).toMatchSnapshot();
+});
+
 function run(content, layout) {
   return remark()
     .use(stylelintToc, { layout })

--- a/plugins/remark-stylelint-toc/index.js
+++ b/plugins/remark-stylelint-toc/index.js
@@ -49,7 +49,10 @@ function addTocHeading(processor, options) {
         if (node.value === tocComment) {
           parent.children = [
             ...parent.children.slice(0, index),
-            tocHeading,
+            {
+              ...tocHeading,
+              depth: parent.children[index + 1].depth
+            },
             ...parent.children.slice(index + 1)
           ];
         }


### PR DESCRIPTION
Currently, it works for `h2`, but with this change, it could be any level.