### PR TITLE
Switch Jest configuration to `jest-preset-stylelint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     ]
   },
   "jest": {
-    "testEnvironment": "node"
+    "preset": "jest-preset-stylelint"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
@@ -156,6 +156,7 @@
     "history": "^2.0.0",
     "husky": "^0.14.3",
     "jest": "^22.0.4",
+    "jest-preset-stylelint": "^1.3.0",
     "lint-staged": "^6.0.0",
     "mdast-util-to-string": "^1.0.2",
     "npm-run-all": "^4.0.2",


### PR DESCRIPTION
This pull request seeks to switch the Jest configuration used in this repo to the newly created [Jest shared preset](https://facebook.github.io/jest/docs/en/configuration.html#preset-string) stylelint organization package [`jest-preset-stylelint`](https://github.com/stylelint/jest-preset-stylelint).

