### PR TITLE
Remove `npm run build` from `npm test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier:check": "prettier '**/*.js' --list-different",
     "prettier:fix": "prettier '**/*.js' --write",
     "pretest": "npm run lint",
-    "test": "jest && npm run build",
+    "test": "jest",
     "precopy": "rimraf content dist",
     "copy": "node ./scripts/copy-stylelint-docs",
     "prestart": "npm run copy",


### PR DESCRIPTION
Is `npm run build` required as part of the `npm test` script?

I've rarely interacted with this repo and running `npm test` just now I noticed it also ran the _build_ script and in my mind doesn't quite align with what expected from a _test_ script.

If it is required, happy for this PR to be closed, if it's not then we should merge this PR.