### PR TITLE
Fix title and description on demo page

### DIFF
--- a/src/layouts/DemoPage/index.js
+++ b/src/layouts/DemoPage/index.js
@@ -1,13 +1,22 @@
+import PropTypes from "prop-types";
 import React from "react";
+import Helmet from "react-helmet";
 
 import Demo from "../../components/Demo";
 
 import styles from "./index.css";
 
-const DemoPage = () => (
+const meta = head => [{ name: "description", content: head.description }];
+
+const DemoPage = ({ head }) => (
   <div className={styles.demoPage}>
+    <Helmet title={head.title} meta={meta(head)} />
     <Demo />
   </div>
 );
+
+DemoPage.propTypes = {
+  head: PropTypes.object.isRequired
+};
 
 export default DemoPage;


### PR DESCRIPTION
This PR fixes a empty title and description on the demo page (https://stylelint.io/demo/).

The title and description for the demo page is created by the following script:

https://github.com/stylelint/stylelint.io/blob/d1b0c6e54786cd07959fdec53f6ae8ee23a0e735/scripts/copy-stylelint-docs.js#L68-L74

However, these aren't applied to the actual page.

The reason is that `<Helmet>` component (by `react-helmet`) is missing in the layout component for the demo page.
This PR adds `<Helmet>` and sets the correct title and description.

### Before

![image](https://user-images.githubusercontent.com/473530/47788781-11c74c80-dd56-11e8-8113-9da44acb6b84.png)

### After

![image](https://user-images.githubusercontent.com/473530/47788680-c57c0c80-dd55-11e8-85a1-8c77ac4d9d20.png)

Fixes <https://github.com/stylelint/stylelint-demo/issues/129>