### PR TITLE
Fix title on rule pages

### DIFF
--- a/scripts/copy-stylelint-docs.js
+++ b/scripts/copy-stylelint-docs.js
@@ -49,7 +49,7 @@ fs.readFile(listOfRulesPath, "utf8", function(err, data) {
 
       fs.writeFile(
         rulePath,
-        `---\nlayout: RulePage\nnext: ${nextRulePath}\nprev: ${prevRulePath}\n---\n\n` +
+        `---\nlayout: RulePage\nnext: ${nextRulePath}\nprev: ${prevRulePath}\n---\n` +
           data
       );
     });


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

## Description

Fix the title on rule pages, for example ([https://stylelint.io/user-guide/rules/color-no-invalid-hex/](https://stylelint.io/user-guide/rules/color-no-invalid-hex/)).

`loader-plugin-markdown-init-head.title-property-from-content` sets the title from the first line except front matter in Markdown.

https://github.com/stylelint/stylelint.io/blob/6789e041547b9951e48d909c6658b6436a0611b9/plugins/loader-plugin-markdown-init-head.title-property-from-content/index.js#L13

But currently the first line of the rule page becomes empty.

```
---
layout:  RulePage
next:  /user-guide/rules/font-family-no-duplicate-names/
prev:  null
---
                                    // <- here
# color-no-invalid-hex
```

This PR removes the empty first line so that the title will be set correctly.

### before

<img width="535" alt="before" src="https://user-images.githubusercontent.com/35105763/55668756-ffbf7c00-58a8-11e9-8325-d92736a1a270.png">

### after

<img width="535" alt="after" src="https://user-images.githubusercontent.com/35105763/55668758-06e68a00-58a9-11e9-95be-d25be137d12b.png">
