### PR TITLE
Revert "Fix changelog Table of Content (#73)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "remark": "^10.0.1",
-    "remark-inline-links": "^3.1.3",
     "rimraf": "^2.6.3",
     "stylelint": "^10.1.0",
     "stylelint-config-standard": "^18.3.0",

--- a/scripts/generate-stylelint-docs.js
+++ b/scripts/generate-stylelint-docs.js
@@ -3,7 +3,6 @@ const fs = require("fs");
 const path = require("path");
 const glob = require("glob");
 const remark = require("remark");
-const inlineLinks = require("remark-inline-links");
 const visit = require("unist-util-visit");
 
 // NOTE: Since Node 10.12.0, `fs.mkdirSync(dir, { recursive: true })` has been supported.
@@ -33,7 +32,6 @@ function processMarkdown(file, { rewriter }) {
 
   const content = remark()
     .use(rewriteLink, { rewriter })
-    .use(inlineLinks)
     .processSync(fs.readFileSync(file, "utf8"))
     .toString();
 


### PR DESCRIPTION
Revert https://github.com/stylelint/stylelint.io/pull/73, because links like https://stylelint.io/changelog#1010 stopped working, and right sidebar links to Github instead of section of the page. We need to find another solution for https://github.com/stylelint/stylelint.io/issues/69