### PR TITLE
Remove unnecessary `async` from `generate-stylelint-docs.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "env": {
       "browser": true,
       "node": true
+    },
+    "rules": {
+      "require-await": "error"
     }
   },
   "stylelint": {

--- a/scripts/generate-stylelint-docs.js
+++ b/scripts/generate-stylelint-docs.js
@@ -80,7 +80,7 @@ function addHostingInfo(content) {
 function main(outputDir) {
   fs.mkdirSync(outputDir);
 
-  glob.sync("node_modules/stylelint/*.md").forEach(async file => {
+  glob.sync("node_modules/stylelint/*.md").forEach(file => {
     let output = processMarkdown(file, {
       rewriter: url =>
         url.replace(/^\/?docs\//, "").replace("README.md", "index.md")


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #78 

> Is there anything in the PR that needs further explanation?

Also, to prevent such problems in the future, this enables the [`require-await`](https://eslint.org/docs/rules/require-await) rule of ESLint.