### PR TITLE
Improve homepage title

### DIFF
--- a/scripts/generate-stylelint-docs.js
+++ b/scripts/generate-stylelint-docs.js
@@ -48,7 +48,6 @@ function processMarkdown(file, { rewriter }) {
     stylelint: "Home"
   };
   const sidebarLabel = titleToSidebarLabel[title] || title;
-
   return `---
 title: ${title}
 sidebar_label: ${sidebarLabel}

--- a/scripts/generate-stylelint-docs.js
+++ b/scripts/generate-stylelint-docs.js
@@ -4,6 +4,7 @@ const path = require("path");
 const glob = require("glob");
 const remark = require("remark");
 const visit = require("unist-util-visit");
+const siteConfig = require("../website/siteConfig");
 
 // NOTE: Since Node 10.12.0, `fs.mkdirSync(dir, { recursive: true })` has been supported.
 //
@@ -36,11 +37,18 @@ function processMarkdown(file, { rewriter }) {
     .toString();
 
   // Add Docusaurus-specific fields. See https://docusaurus.io/docs/en/doc-markdown
-  const title = content.match(/\n?# ([^\n]+)\n/)[1];
+  let title = content.match(/\n?# ([^\n]+)\n/)[1];
+
+  if (title === "stylelint") {
+    // Check for homepage
+    title = siteConfig.tagline;
+  }
+
   const titleToSidebarLabel = {
     stylelint: "Home"
   };
   const sidebarLabel = titleToSidebarLabel[title] || title;
+
   return `---
 title: ${title}
 sidebar_label: ${sidebarLabel}

--- a/scripts/generate-stylelint-docs.js
+++ b/scripts/generate-stylelint-docs.js
@@ -38,16 +38,16 @@ function processMarkdown(file, { rewriter }) {
 
   // Add Docusaurus-specific fields. See https://docusaurus.io/docs/en/doc-markdown
   let title = content.match(/\n?# ([^\n]+)\n/)[1];
+  const titleToSidebarLabel = {
+    stylelint: "Home"
+  };
+  const sidebarLabel = titleToSidebarLabel[title] || title;
 
   if (title === "stylelint") {
     // Check for homepage
     title = siteConfig.tagline;
   }
 
-  const titleToSidebarLabel = {
-    stylelint: "Home"
-  };
-  const sidebarLabel = titleToSidebarLabel[title] || title;
   return `---
 title: ${title}
 sidebar_label: ${sidebarLabel}


### PR DESCRIPTION
Closes #71 

> Is there anything in the PR that needs further explanation?

It seems that the title tagline combination can only work with custom pages. For example, the demo page can have title `stylelint  ·  A mighty, modern style linter` if this line was not specified: `Demo.title = "Demo";`.
With markdown pages, as far as I managed to understand, it uses either the title from the metadata, if none, then uses the id, if none - then uses the name of the file - this way `props.title` is always present and it never goes in the else part of the condition (https://github.com/facebook/docusaurus/blob/v1.11.1/packages/docusaurus-1.x/lib/core/Site.js#L38-L42).
