### PR TITLE
Change: `npm install` -> `npm ci`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The source of stylelint website.
 To get started:
 
 ```shell
-npm install
+npm ci
 ```
 
 Then to making visual edits:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "postinstall": "cd website && npm install",
+    "postinstall": "cd website && npm ci",
     "lint:js": "eslint . --ignore-path .gitignore",
     "lint:css": "stylelint --ignore-path .gitignore \"**/*.css\"",
     "lint": "npm-run-all --parallel lint:*",


### PR DESCRIPTION
`package-lock.json` has been added on PR #87. I think we should use `npm ci` instead of `npm install`.