### PR TITLE
Add "Edit" button

### DIFF
--- a/scripts/generate-stylelint-docs.js
+++ b/scripts/generate-stylelint-docs.js
@@ -54,10 +54,16 @@ function processMarkdown(file, { rewriter }) {
     title = siteConfig.tagline;
   }
 
+  const editPath = file
+    .replace(path.join("node_modules", "stylelint"), "")
+    .replace(/\\/g, "/")
+    .substring(1);
+
   return `---
 title: ${title}
 sidebar_label: ${sidebarLabel}
 hide_title: true
+custom_edit_url: https://github.com/stylelint/stylelint/edit/master/${editPath}
 ---
 
 ${content}`;


### PR DESCRIPTION
By adding the `custom_edit_url` field to Markdown headers in each document.
See <https://docusaurus.io/docs/en/doc-markdown#documents> for details.

![Oct-31-2019 13-34-47](https://user-images.githubusercontent.com/473530/67919352-5d1f6f80-fbe3-11e9-9737-069ca044670e.gif)
