### PR TITLE
Lower Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "https://github.com/stylelint/stylelint.io.git",
   "engines": {
-    "node": ">=12"
+    "node": ">=10.12.0"
   },
   "scripts": {
     "postinstall": "cd website && npm install",


### PR DESCRIPTION
We don't really need to enforce Node.js version that much. Currenly I'm stuck with Node.js 10 on my computer and can't upgrade to Node.js 12. Also I don't want to mess with different Node.js versions with NVM either.

We enforced version 12 recently (https://github.com/stylelint/stylelint.io/pull/106). `10.12.0` would be more that sufficient for contributors.