### PR TITLE
Tweak nav item positions

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,4 +1,11 @@
 /* your custom css */
+.navigationSlider .slidingNav ul li {
+  flex: none;
+}
+
+.navigationSlider .slidingNav ul li:nth-child(4) {
+  margin-left: auto;
+}
 
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
   /* insert here if you need */
@@ -13,6 +20,11 @@
   body .wrapper,
   body .headerWrapper.wrapper {
     max-width: 1400px;
+  }
+
+  .navigationSlider {
+    margin-left: 168px;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

It's a visual tweak.

> Is there anything in the PR that needs further explanation?

It separates the external links from the internal navigation, including search. It's a stepping stone to what the [navigation will be like](https://v2.docusaurus.io/) when we update to docusaurus@2.

<img width="1042" alt="Screenshot 2020-03-12 at 19 18 48" src="https://user-images.githubusercontent.com/808227/76561483-4cd5a600-649b-11ea-8aa1-1bd1663bc172.png">

