### PR TITLE
Use Prettier for all supported formats

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
 
-    - name: Install latest npm
-      run: npm install --global npm@latest
+      - name: Install latest npm
+        run: npm install --global npm@latest
 
-    - name: npm ci, and test
-      run: |
-        npm ci
-        npm test
+      - name: npm ci, and test
+        run: |
+          npm ci
+          npm test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # stylelint.io
 
-
 [![Build Status](https://github.com/stylelint/stylelint.io/workflows/CI/badge.svg)](https://github.com/stylelint/stylelint.io)
 
 The source of stylelint website.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "lint:js": "eslint . --ignore-path .gitignore",
     "lint:css": "stylelint --ignore-path .gitignore \"**/*.css\"",
     "lint": "npm-run-all --parallel lint:*",
-    "prettier:check": "prettier '**/*.js' --check",
-    "prettier:fix": "prettier '**/*.js' --write",
+    "prettier:check": "prettier . --check --ignore-path .gitignore",
+    "prettier:fix": "prettier . --write --ignore-path .gitignore",
     "pretest": "npm run lint",
     "test": "npm run build",
     "pregendoc": "rimraf docs",
@@ -85,9 +85,9 @@
     }
   },
   "lint-staged": {
-    "*.js": [
-      "prettier --write"
-    ]
+    "*.js": "eslint --cache --fix",
+    "*.css": "stylelint --cache --fix",
+    "*.{js,json,css,md,yml}": "prettier --write"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/website/README.md
+++ b/website/README.md
@@ -2,11 +2,11 @@ This website was created with [Docusaurus](https://docusaurus.io/).
 
 # What's In This Document
 
-* [Get Started in 5 Minutes](#get-started-in-5-minutes)
-* [Directory Structure](#directory-structure)
-* [Editing Content](#editing-content)
-* [Adding Content](#adding-content)
-* [Full Documentation](#full-documentation)
+- [Get Started in 5 Minutes](#get-started-in-5-minutes)
+- [Directory Structure](#directory-structure)
+- [Editing Content](#editing-content)
+- [Adding Content](#adding-content)
+- [Full Documentation](#full-documentation)
 
 # Get Started in 5 Minutes
 
@@ -16,6 +16,7 @@ This website was created with [Docusaurus](https://docusaurus.io/).
 # Install dependencies
 $ yarn
 ```
+
 2. Run your dev server:
 
 ```sh
@@ -72,6 +73,7 @@ For more information about docs, click [here](https://docusaurus.io/docs/en/navi
 Edit blog posts by navigating to `website/blog` and editing the corresponding post:
 
 `website/blog/post-to-be-edited.md`
+
 ```markdown
 ---
 id: post-needs-edit
@@ -121,6 +123,7 @@ For more information about adding new docs, click [here](https://docusaurus.io/d
 1. Make sure there is a header link to your blog in `website/siteConfig.js`:
 
 `website/siteConfig.js`
+
 ```javascript
 headerLinks: [
     ...
@@ -151,6 +154,7 @@ For more information about blog posts, click [here](https://docusaurus.io/docs/e
 1. Add links to docs, custom pages or external links by editing the headerLinks field of `website/siteConfig.js`:
 
 `website/siteConfig.js`
+
 ```javascript
 {
   headerLinks: [
@@ -175,6 +179,7 @@ For more information about the navigation bar, click [here](https://docusaurus.i
 1. If you want your page to show up in your navigation header, you will need to update `website/siteConfig.js` to add to the `headerLinks` element:
 
 `website/siteConfig.js`
+
 ```javascript
 {
   headerLinks: [


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Uses `prettier .`, which is introduced in version 2.

Unfortunately, it seems we need to manually specify the file extensions for `lint-staged`.
