### PR TITLE
Update Docusaurus to v2.0.0-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/preset-classic": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/preset-classic": "2.0.0-beta.6",
         "@stylelint/prettier-config": "^2.0.0",
         "@stylelint/remark-preset": "^3.0.0",
         "eslint": "^7.32.0",
@@ -1804,9 +1804,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.5.tgz",
-      "integrity": "sha512-LERPgERVmui0Fb/aIEsd0/1O8VMWW2+vokoPJFHsCswNkk+63C+Ko6luu2z1QoXhbUGAVEJKTb4Z2NAZ5eSF5Q==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.6.tgz",
+      "integrity": "sha512-XMeI+lJKeJBGYBNOfO/Tc+5FMf21E5p1xZjfe75cgYcfZdERZ+W7aemXquwReno8xxHb4Rnfmi9dxkbOLDjqDA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.16",
@@ -1819,12 +1819,12 @@
         "@babel/runtime": "^7.12.5",
         "@babel/runtime-corejs3": "^7.12.13",
         "@babel/traverse": "^7.12.13",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.5",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.6",
         "@docusaurus/react-loadable": "5.5.0",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-common": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-common": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.0",
         "@svgr/webpack": "^5.5.0",
         "autoprefixer": "^10.2.5",
@@ -1901,9 +1901,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.5.tgz",
-      "integrity": "sha512-qbGj3X5jcAuA/Nr6EKGRFUGYnMXAuuBg0PyJpKGXLi9/wuIGGuuO/FED2L3f9AONWXZmZuwtKQGXeGtVN8sKEg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.6.tgz",
+      "integrity": "sha512-RCizp2NAbADopkX5nUz1xrAbU6hGZzziQk9RdSDGJLzMgVCN6RDotq9odS8VgzNa9x2Lx3WN527UxeEbzc2GVQ==",
       "dev": true,
       "dependencies": {
         "cssnano-preset-advanced": "^5.1.1",
@@ -1912,15 +1912,15 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.5.tgz",
-      "integrity": "sha512-6e1SPIIEuXomdpYnP3dkAu/6Y6aInu5vRBBc1GjLvy1RzrX1NTLdQtNdjjaEctP0eyddkyc9tkQwH0p2Wav8Zw==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.6.tgz",
+      "integrity": "sha512-yO6N+OESR77WZ/pXz7muOJGLletYYksx7s7wrwrr0x+A8tzdSwiHZ9op0NyjjpW5AnItU/WQQfcjv37qv4K6HA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.12.16",
         "@babel/traverse": "^7.12.13",
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
         "@mdx-js/mdx": "^1.6.21",
         "@mdx-js/react": "^1.6.21",
         "chalk": "^4.1.1",
@@ -1974,16 +1974,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.5.tgz",
-      "integrity": "sha512-gZmsBKibSE6/0LeGtpPtcRCvbl8XnRwsWhDGVf13CswnKSwmyE7FWq1ymAzgA4xJx//UamaRzZB9449+l2HVCg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.6.tgz",
+      "integrity": "sha512-ohfMt7+rPiFQImc4Clpvc9m/1yWUQAjpG3e/coJywlJYbDXvi1pmH0VKkDUMBSe/35Wtz9457DYgNFG81lhV7Q==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/mdx-loader": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/mdx-loader": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "chalk": "^4.1.1",
         "escape-string-regexp": "^4.0.0",
         "feed": "^4.2.2",
@@ -2006,16 +2006,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.5.tgz",
-      "integrity": "sha512-9WXa+UK4/oOnGdk2aWLfE/151v6tf4jgxgRSM+V9jH9FQiluG5APDz0lH62wSTZbl8PjflK5BBhl17tCjGvvgQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.6.tgz",
+      "integrity": "sha512-cM5WWogWmX+qKPKv332eDWGRVVT5OjskbmFKe2QimwoaON3Cv6XY8Fo2xdYopqGIU0r0z8dVtRmoGS0ji7zB7w==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/mdx-loader": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/mdx-loader": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "chalk": "^4.1.1",
         "combine-promises": "^1.1.0",
         "escape-string-regexp": "^4.0.0",
@@ -2067,16 +2067,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.5.tgz",
-      "integrity": "sha512-1amYXgCc+ZqU8KScwG5zXWIGcy9OdrmmhB6LUuE+vfn+jVOdn8oVTkR8JTVMqmvLhyxmL30ixO06UsstQvKAJQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.6.tgz",
+      "integrity": "sha512-N6wARzOA8gTFeBXZSKbAN5s1Ej6R/pVg+J946E8GCYefXTFikTNRQ8+OPhax4MRzgzoOvhTQbLbRCSoAzSmjig==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/mdx-loader": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/mdx-loader": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "globby": "^11.0.2",
         "lodash": "^4.17.20",
         "remark-admonitions": "^1.2.1",
@@ -2092,14 +2092,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.5.tgz",
-      "integrity": "sha512-ITrgRNic+NY9HMzUKzYhh6Mz/tgKQjdJYVizA/kbP5pkjB8FunE+0B12km9UNBzuT4ETGdNKgQGAqzrcrjpnag==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.6.tgz",
+      "integrity": "sha512-TJXDBR2Gr/mhBrcj+/4+rTShSm/Qg56Jfezbm/2fFvuPgVlUwy6oj08s2/kYSTmkfG7G+c4iX1GBHjtyo1KxZA==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "fs-extra": "^9.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.1.0"
       },
@@ -2111,13 +2112,28 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.5.tgz",
-      "integrity": "sha512-ncG+SCafoqFhtOMJwk9IZbzZCdy1bgmOjNCSfF6mmDp9laYYJBplBtqItIBQTuycIyKCxznKzi2q8l9989uMrA==",
+    "node_modules/@docusaurus/plugin-debug/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5"
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics": {
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.6.tgz",
+      "integrity": "sha512-AHbMNPN3gkWXYFnmHL9MBcRODByAgzHZoH/5v3xwbSV2FOZo6kx4Hp94I6oFM0o5mp+i6X7slDncgGTWSGxCMg==",
+      "dev": true,
+      "dependencies": {
+        "@docusaurus/core": "2.0.0-beta.6"
       },
       "engines": {
         "node": ">=12.13.0"
@@ -2128,12 +2144,12 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.5.tgz",
-      "integrity": "sha512-FMWAXCLCUwEk7wykOAcM6vs3tHWVIU/T1PElqcoD7fh9521ocZ/5L8yyWWfJ+nX/90TVs+7nOFY0vNl2I2MYZg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.6.tgz",
+      "integrity": "sha512-uJyQ30sXbVRS3TGtVJFA0s1ozrluuREu6NK2Z3TLtKpeT2NTe5iaqXN0Xp749hr3bjbgpEe6gMixVh//jg503w==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5"
+        "@docusaurus/core": "2.0.0-beta.6"
       },
       "engines": {
         "node": ">=12.13.0"
@@ -2144,16 +2160,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.5.tgz",
-      "integrity": "sha512-QcIIMNmyMnOm5q/zyzidixNIB+yE7/ouUi/62wr5+ZkO/rvvObVe+r9Tdl90SmvsJH17y290EWEy9kunoRyG0w==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.6.tgz",
+      "integrity": "sha512-jpTaODqyCgg+20RtMw8gSvCKQOvH18FpKhIu6FG+z4zgHP33qaJouVM7/1ZKPrfNt4z7xDOyBNUzzdmpssHA8A==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-common": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-common": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "fs-extra": "^10.0.0",
         "sitemap": "^7.0.0",
         "tslib": "^2.2.0"
@@ -2167,21 +2183,21 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.5.tgz",
-      "integrity": "sha512-hcPLYwMEMDuc/lNloDRh3SKpZneQLaz0Zj8CI7jsislp4iBz9QtbWZzruoXsJe7noSfqsBcTJqRlNw7/UwEyTA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.6.tgz",
+      "integrity": "sha512-riqQRcNssNH7oto8nAjYIO79/ZucidexHTDlgD+trP56ploHLJp4kIlxb44IGOmx3es8/z4egWtM+acY/39N2Q==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.5",
-        "@docusaurus/plugin-debug": "2.0.0-beta.5",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.5",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.5",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.5",
-        "@docusaurus/theme-classic": "2.0.0-beta.5",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.5"
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.6",
+        "@docusaurus/plugin-debug": "2.0.0-beta.6",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.6",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.6",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.6",
+        "@docusaurus/theme-classic": "2.0.0-beta.6",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.6"
       },
       "engines": {
         "node": ">=12.13.0"
@@ -2204,20 +2220,20 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.5.tgz",
-      "integrity": "sha512-AtBifB1mRMI5W0ORlY5M/QEnHUB/wvGLRkLegBbgBAiTy2IGr99GUXRRminQI2AQuFTwYAMLQoSVSeJ0w1q49g==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.6.tgz",
+      "integrity": "sha512-fMb6gAKUdaojInZabimIJE+yPWs8dQfmZII7v/LHmgxafh/FylmrBkKhyJfa2ix4QRibo9E01LGX44/aKzemxw==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.5",
-        "@docusaurus/theme-common": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-common": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.6",
+        "@docusaurus/theme-common": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-common": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "@mdx-js/mdx": "^1.6.21",
         "@mdx-js/react": "^1.6.21",
         "chalk": "^4.1.1",
@@ -2225,7 +2241,7 @@
         "copy-text-to-clipboard": "^3.0.1",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.2",
-        "infima": "0.2.0-alpha.31",
+        "infima": "0.2.0-alpha.33",
         "lodash": "^4.17.20",
         "parse-numeric-range": "^1.2.0",
         "postcss": "^8.2.15",
@@ -2244,16 +2260,16 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.5.tgz",
-      "integrity": "sha512-6XEM8NzpR2Q42qkhPdI46M/7lLcZcOCgqmQfmj319sGmKkfhPuYPuIUvNqorxldZqLYuV8/9q7WAPjAgj+wawA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.6.tgz",
+      "integrity": "sha512-53nFWMjpFdyHEvBfQQQoDm9rNKgGangy7vSp1B/F3+uRyYAItE7O4l8MdOALXFALlddiiPYvCtI1qGx2dnzndA==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
         "clsx": "^1.1.1",
         "fs-extra": "^10.0.0",
         "tslib": "^2.1.0"
@@ -2268,16 +2284,16 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.5.tgz",
-      "integrity": "sha512-+3XG4SHJ4xukvv/WDKRejf3qSTVa3ufOv6hlZ32H8RAmfJmI/Rmsm/oueB86xBw/OkznIXx6M8HzchfYCHWxSA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.6.tgz",
+      "integrity": "sha512-GaaYdf6EEKL3jwmt9LRyiMtNvobOhw4vGuYJKbJcgba/M75kOJSbZPRrhALBAe6o4gOYbV44afzFC/jUUp7dsA==",
       "dev": true,
       "dependencies": {
         "@docsearch/react": "^3.0.0-alpha.39",
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/theme-common": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/theme-common": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "algoliasearch": "^4.8.4",
         "algoliasearch-helper": "^3.3.4",
         "clsx": "^1.1.1",
@@ -2293,9 +2309,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.5.tgz",
-      "integrity": "sha512-WtwR5O67cTK6wo9KnSxqBpgC26M6Z90PgX5Gun/Re8Ix+GVEqIzzev9C/2P2Da2TW0sgSkjWNr1tHaNxNMPLkQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.6.tgz",
+      "integrity": "sha512-TrwxyI93XTZEhOmdEI8FPKDbGV61zE9PzXCdE1alwz1NOV+YXwcv+9sRTZEVLqBpr+TIja+IeeS6mxnyen/Ptg==",
       "dev": true,
       "dependencies": {
         "commander": "^5.1.0",
@@ -2306,12 +2322,12 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.5.tgz",
-      "integrity": "sha512-hIzuARFMqXqljTdbF19bYRw+fqqK2gHlzepeC9uJfLLaGmirPFDPjr+BN9oiajBhNx2CgvJVl/66lEx4hrd7uQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.6.tgz",
+      "integrity": "sha512-S72/o7VDaTvrXJy+NpfuctghGGoMW30m94PMkrL3I6V+o5eE2Uzax7dbM++moclmHvi0/Khv+TXmRIQs6ZvwgQ==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/types": "2.0.0-beta.5",
+        "@docusaurus/types": "2.0.0-beta.6",
         "@types/github-slugger": "^1.3.0",
         "chalk": "^4.1.1",
         "escape-string-regexp": "^4.0.0",
@@ -2328,12 +2344,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.5.tgz",
-      "integrity": "sha512-LUHEfZ9QGwBCpmGfLiPz5ENipxicsBlzIu+jUuB6I+ljX4Cd2OFkjDVmL0kjHR80sh0KJzNizpjsVj3l3jN9RA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.6.tgz",
+      "integrity": "sha512-MKm6bJxvsYWRl072jLR60z+71tTWSxoERh2eTmCYlegFnu3Tby3HOC8I3jDcC6VpVuoDGsBGNoQbOgy2LqQbXQ==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/types": "2.0.0-beta.5",
+        "@docusaurus/types": "2.0.0-beta.6",
         "tslib": "^2.2.0"
       },
       "engines": {
@@ -2341,12 +2357,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.5.tgz",
-      "integrity": "sha512-VWj1BRYejcGewWP3BKSm3a5dVzQWA9w9MDQUCylR2NxywOxonoUPo9nz5g9bN+C3rwuelfA5u3MORu2q2+rbLw==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.6.tgz",
+      "integrity": "sha512-v0nk9bpawUd2JFDFyiHDmZuMG+/O1UvxtxvcRbvrxrul+rlzD7Q9CGxMgW3Grp2OCKQ4yFXRidBIccwqON5AVw==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/utils": "2.0.0-beta.5",
+        "@docusaurus/utils": "2.0.0-beta.6",
         "chalk": "^4.1.1",
         "joi": "^17.4.0",
         "tslib": "^2.1.0"
@@ -3186,9 +3202,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
-      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
+      "version": "17.0.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz",
+      "integrity": "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -3939,6 +3955,15 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -3952,15 +3977,15 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.3.tgz",
-      "integrity": "sha512-yRzjxfnggrP/+qVHlUuZz5FZzEbkT+Yt0/Df6ScEMnbbZBLzYB2W0KLxoQCW+THm1SpOsM1ZPcTHAwuvmibIsQ==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.6.tgz",
+      "integrity": "sha512-3bDjTfF0MfZntwVCSd18XAT2Zndufh3Mep+mafbzdIQEeWbncVRUVDjH8/EPANV9Hq40seJ24QcYAyhUsFz7gQ==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.16.8",
-        "caniuse-lite": "^1.0.30001252",
-        "colorette": "^1.3.0",
+        "browserslist": "^4.17.1",
+        "caniuse-lite": "^1.0.30001260",
         "fraction.js": "^4.1.1",
+        "nanocolors": "^0.2.8",
         "normalize-range": "^0.1.2",
         "postcss-value-parser": "^4.1.0"
       },
@@ -4330,16 +4355,16 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.16.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
-      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.2.tgz",
+      "integrity": "sha512-jSDZyqJmkKMEMi7SZAgX5UltFdR5NAO43vY0AwTpu4X3sGH7GLLQ83KiUomgrnvZRCeW0yPPnKqnxPqQOER9zQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001251",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.811",
+        "caniuse-lite": "^1.0.30001261",
+        "electron-to-chromium": "^1.3.854",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "nanocolors": "^0.2.12",
+        "node-releases": "^1.1.76"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4536,9 +4561,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001252",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+      "version": "1.0.30001264",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
+      "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5842,9 +5867,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
       "dev": true,
       "peer": true
     },
@@ -6401,9 +6426,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.826",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.826.tgz",
-      "integrity": "sha512-bpLc4QU4B8PYmdO4MSu2ZBTMD8lAaEXRS43C09lB31BvYwuk9UxgBRXbY5OJBw7VuMGcg2MZG5FyTaP9u4PQnw==",
+      "version": "1.3.857",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.857.tgz",
+      "integrity": "sha512-a5kIr2lajm4bJ5E4D3fp8Y/BRB0Dx2VOcCRE5Gtb679mXIME/OFhWler8Gy2ksrf8gFX+EFCSIGA33FB3gqYpg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -7674,9 +7699,9 @@
       "dev": true
     },
     "node_modules/flux": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.1.tgz",
-      "integrity": "sha512-emk4RCvJ8RzNP2lNpphKnG7r18q8elDYNAPx7xn+bDeOIo9FFfxEfIQ2y6YbQNmnsGD3nH1noxtLE64Puz1bRQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.2.tgz",
+      "integrity": "sha512-u/ucO5ezm3nBvdaSGkWpDlzCePoV+a9x3KHmy13TV/5MzOaCZDN8Mfd94jmf0nOi8ZZay+nOKbBUkOe2VNaupQ==",
       "dev": true,
       "dependencies": {
         "fbemitter": "^3.0.0",
@@ -9328,9 +9353,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.31",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.31.tgz",
-      "integrity": "sha512-ggOAeyiQIFKZeYnH9lbhDBHFZhcYOa0LFKSMLgot33X21aJRu7ruwVUVwYg4kJnZRLGLeAjC5BVgLxKoLixuNQ==",
+      "version": "0.2.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.33.tgz",
+      "integrity": "sha512-iLZI8/vGTbbhbeFhlWv1zwvrqfNDLAayuEdqZqNqCyGuh0IW469dRIRm0FLZ98YyLikt2njzuKfy6xUrBWRXcg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -12009,6 +12034,12 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/nanocolors": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
+      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
+      "dev": true
+    },
     "node_modules/nanoid": {
       "version": "3.1.23",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
@@ -12133,9 +12164,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "version": "1.1.77",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -14296,18 +14327,18 @@
       }
     },
     "node_modules/postcss-sort-media-queries": {
-      "version": "3.11.12",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-3.11.12.tgz",
-      "integrity": "sha512-PNhEOWR/btZ0bNNRqqdW4TWxBPQ1mu2I6/Zpco80vBUDSyEjtduUAorY0Vm68rvDlGea3+sgEnQ36iQ1A/gG8Q==",
+      "version": "3.12.13",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-3.12.13.tgz",
+      "integrity": "sha512-bFbR1+P6HhZWXcT5DVV2pBH5Y2U5daKbFd0j+kcwKdzrxkbmgFu0GhI2JfFUyy5KQIeW+YJGP+vwNDOS5hIn2g==",
       "dev": true,
       "dependencies": {
-        "sort-css-media-queries": "1.5.4"
+        "sort-css-media-queries": "2.0.4"
       },
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "postcss": "^8.3.1"
+        "postcss": "^8.3.6"
       }
     },
     "node_modules/postcss-sorting": {
@@ -14726,9 +14757,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
+      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==",
       "dev": true
     },
     "node_modules/process-nextick-args": {
@@ -15487,9 +15518,9 @@
       }
     },
     "node_modules/reading-time": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.4.0.tgz",
-      "integrity": "sha512-0I9aP583rqQhm6T6Y+pYgYaM4w649VHgQPC24xSWXpn/4qRs08Zu6KgXRf0da6/k7IHoC6idm76fU6vz4mmzHQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
       "dev": true
     },
     "node_modules/rechoir": {
@@ -23453,9 +23484,9 @@
       }
     },
     "node_modules/sort-css-media-queries": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-1.5.4.tgz",
-      "integrity": "sha512-YP5W/h4Sid/YP7Lp87ejJ5jP13/Mtqt2vx33XyhO+IAugKlufRPbOrPlIiEUuxmpNBSBd3EeeQpFhdu3RfI2Ag==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.0.4.tgz",
+      "integrity": "sha512-PAIsEK/XupCQwitjv7XxoMvYhT7EAfyzI3hsy/MyDgTvc+Ft55ctdkctJLOy6cQejaIC+zjpUL4djFVm2ivOOw==",
       "dev": true,
       "engines": {
         "node": ">= 6.3.0"
@@ -29309,9 +29340,9 @@
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.5.tgz",
-      "integrity": "sha512-LERPgERVmui0Fb/aIEsd0/1O8VMWW2+vokoPJFHsCswNkk+63C+Ko6luu2z1QoXhbUGAVEJKTb4Z2NAZ5eSF5Q==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.6.tgz",
+      "integrity": "sha512-XMeI+lJKeJBGYBNOfO/Tc+5FMf21E5p1xZjfe75cgYcfZdERZ+W7aemXquwReno8xxHb4Rnfmi9dxkbOLDjqDA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.16",
@@ -29324,12 +29355,12 @@
         "@babel/runtime": "^7.12.5",
         "@babel/runtime-corejs3": "^7.12.13",
         "@babel/traverse": "^7.12.13",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.5",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.6",
         "@docusaurus/react-loadable": "5.5.0",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-common": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-common": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.0",
         "@svgr/webpack": "^5.5.0",
         "autoprefixer": "^10.2.5",
@@ -29396,9 +29427,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.5.tgz",
-      "integrity": "sha512-qbGj3X5jcAuA/Nr6EKGRFUGYnMXAuuBg0PyJpKGXLi9/wuIGGuuO/FED2L3f9AONWXZmZuwtKQGXeGtVN8sKEg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.6.tgz",
+      "integrity": "sha512-RCizp2NAbADopkX5nUz1xrAbU6hGZzziQk9RdSDGJLzMgVCN6RDotq9odS8VgzNa9x2Lx3WN527UxeEbzc2GVQ==",
       "dev": true,
       "requires": {
         "cssnano-preset-advanced": "^5.1.1",
@@ -29407,15 +29438,15 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.5.tgz",
-      "integrity": "sha512-6e1SPIIEuXomdpYnP3dkAu/6Y6aInu5vRBBc1GjLvy1RzrX1NTLdQtNdjjaEctP0eyddkyc9tkQwH0p2Wav8Zw==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.6.tgz",
+      "integrity": "sha512-yO6N+OESR77WZ/pXz7muOJGLletYYksx7s7wrwrr0x+A8tzdSwiHZ9op0NyjjpW5AnItU/WQQfcjv37qv4K6HA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.12.16",
         "@babel/traverse": "^7.12.13",
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
         "@mdx-js/mdx": "^1.6.21",
         "@mdx-js/react": "^1.6.21",
         "chalk": "^4.1.1",
@@ -29456,16 +29487,16 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.5.tgz",
-      "integrity": "sha512-gZmsBKibSE6/0LeGtpPtcRCvbl8XnRwsWhDGVf13CswnKSwmyE7FWq1ymAzgA4xJx//UamaRzZB9449+l2HVCg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.6.tgz",
+      "integrity": "sha512-ohfMt7+rPiFQImc4Clpvc9m/1yWUQAjpG3e/coJywlJYbDXvi1pmH0VKkDUMBSe/35Wtz9457DYgNFG81lhV7Q==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/mdx-loader": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/mdx-loader": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "chalk": "^4.1.1",
         "escape-string-regexp": "^4.0.0",
         "feed": "^4.2.2",
@@ -29481,16 +29512,16 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.5.tgz",
-      "integrity": "sha512-9WXa+UK4/oOnGdk2aWLfE/151v6tf4jgxgRSM+V9jH9FQiluG5APDz0lH62wSTZbl8PjflK5BBhl17tCjGvvgQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.6.tgz",
+      "integrity": "sha512-cM5WWogWmX+qKPKv332eDWGRVVT5OjskbmFKe2QimwoaON3Cv6XY8Fo2xdYopqGIU0r0z8dVtRmoGS0ji7zB7w==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/mdx-loader": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/mdx-loader": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "chalk": "^4.1.1",
         "combine-promises": "^1.1.0",
         "escape-string-regexp": "^4.0.0",
@@ -29531,16 +29562,16 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.5.tgz",
-      "integrity": "sha512-1amYXgCc+ZqU8KScwG5zXWIGcy9OdrmmhB6LUuE+vfn+jVOdn8oVTkR8JTVMqmvLhyxmL30ixO06UsstQvKAJQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.6.tgz",
+      "integrity": "sha512-N6wARzOA8gTFeBXZSKbAN5s1Ej6R/pVg+J946E8GCYefXTFikTNRQ8+OPhax4MRzgzoOvhTQbLbRCSoAzSmjig==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/mdx-loader": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/mdx-loader": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "globby": "^11.0.2",
         "lodash": "^4.17.20",
         "remark-admonitions": "^1.2.1",
@@ -29549,68 +29580,83 @@
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.5.tgz",
-      "integrity": "sha512-ITrgRNic+NY9HMzUKzYhh6Mz/tgKQjdJYVizA/kbP5pkjB8FunE+0B12km9UNBzuT4ETGdNKgQGAqzrcrjpnag==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.6.tgz",
+      "integrity": "sha512-TJXDBR2Gr/mhBrcj+/4+rTShSm/Qg56Jfezbm/2fFvuPgVlUwy6oj08s2/kYSTmkfG7G+c4iX1GBHjtyo1KxZA==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "fs-extra": "^9.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.5.tgz",
-      "integrity": "sha512-ncG+SCafoqFhtOMJwk9IZbzZCdy1bgmOjNCSfF6mmDp9laYYJBplBtqItIBQTuycIyKCxznKzi2q8l9989uMrA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.6.tgz",
+      "integrity": "sha512-AHbMNPN3gkWXYFnmHL9MBcRODByAgzHZoH/5v3xwbSV2FOZo6kx4Hp94I6oFM0o5mp+i6X7slDncgGTWSGxCMg==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5"
+        "@docusaurus/core": "2.0.0-beta.6"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.5.tgz",
-      "integrity": "sha512-FMWAXCLCUwEk7wykOAcM6vs3tHWVIU/T1PElqcoD7fh9521ocZ/5L8yyWWfJ+nX/90TVs+7nOFY0vNl2I2MYZg==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.6.tgz",
+      "integrity": "sha512-uJyQ30sXbVRS3TGtVJFA0s1ozrluuREu6NK2Z3TLtKpeT2NTe5iaqXN0Xp749hr3bjbgpEe6gMixVh//jg503w==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5"
+        "@docusaurus/core": "2.0.0-beta.6"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.5.tgz",
-      "integrity": "sha512-QcIIMNmyMnOm5q/zyzidixNIB+yE7/ouUi/62wr5+ZkO/rvvObVe+r9Tdl90SmvsJH17y290EWEy9kunoRyG0w==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.6.tgz",
+      "integrity": "sha512-jpTaODqyCgg+20RtMw8gSvCKQOvH18FpKhIu6FG+z4zgHP33qaJouVM7/1ZKPrfNt4z7xDOyBNUzzdmpssHA8A==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-common": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-common": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "fs-extra": "^10.0.0",
         "sitemap": "^7.0.0",
         "tslib": "^2.2.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.5.tgz",
-      "integrity": "sha512-hcPLYwMEMDuc/lNloDRh3SKpZneQLaz0Zj8CI7jsislp4iBz9QtbWZzruoXsJe7noSfqsBcTJqRlNw7/UwEyTA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.6.tgz",
+      "integrity": "sha512-riqQRcNssNH7oto8nAjYIO79/ZucidexHTDlgD+trP56ploHLJp4kIlxb44IGOmx3es8/z4egWtM+acY/39N2Q==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.5",
-        "@docusaurus/plugin-debug": "2.0.0-beta.5",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.5",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.5",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.5",
-        "@docusaurus/theme-classic": "2.0.0-beta.5",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.5"
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.6",
+        "@docusaurus/plugin-debug": "2.0.0-beta.6",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.6",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.6",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.6",
+        "@docusaurus/theme-classic": "2.0.0-beta.6",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.6"
       }
     },
     "@docusaurus/react-loadable": {
@@ -29623,20 +29669,20 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.5.tgz",
-      "integrity": "sha512-AtBifB1mRMI5W0ORlY5M/QEnHUB/wvGLRkLegBbgBAiTy2IGr99GUXRRminQI2AQuFTwYAMLQoSVSeJ0w1q49g==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.6.tgz",
+      "integrity": "sha512-fMb6gAKUdaojInZabimIJE+yPWs8dQfmZII7v/LHmgxafh/FylmrBkKhyJfa2ix4QRibo9E01LGX44/aKzemxw==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.5",
-        "@docusaurus/theme-common": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-common": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.6",
+        "@docusaurus/theme-common": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-common": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "@mdx-js/mdx": "^1.6.21",
         "@mdx-js/react": "^1.6.21",
         "chalk": "^4.1.1",
@@ -29644,7 +29690,7 @@
         "copy-text-to-clipboard": "^3.0.1",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.2",
-        "infima": "0.2.0-alpha.31",
+        "infima": "0.2.0-alpha.33",
         "lodash": "^4.17.20",
         "parse-numeric-range": "^1.2.0",
         "postcss": "^8.2.15",
@@ -29656,32 +29702,32 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.5.tgz",
-      "integrity": "sha512-6XEM8NzpR2Q42qkhPdI46M/7lLcZcOCgqmQfmj319sGmKkfhPuYPuIUvNqorxldZqLYuV8/9q7WAPjAgj+wawA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.6.tgz",
+      "integrity": "sha512-53nFWMjpFdyHEvBfQQQoDm9rNKgGangy7vSp1B/F3+uRyYAItE7O4l8MdOALXFALlddiiPYvCtI1qGx2dnzndA==",
       "dev": true,
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.5",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.5",
-        "@docusaurus/types": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.6",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.6",
+        "@docusaurus/types": "2.0.0-beta.6",
         "clsx": "^1.1.1",
         "fs-extra": "^10.0.0",
         "tslib": "^2.1.0"
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.5.tgz",
-      "integrity": "sha512-+3XG4SHJ4xukvv/WDKRejf3qSTVa3ufOv6hlZ32H8RAmfJmI/Rmsm/oueB86xBw/OkznIXx6M8HzchfYCHWxSA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.6.tgz",
+      "integrity": "sha512-GaaYdf6EEKL3jwmt9LRyiMtNvobOhw4vGuYJKbJcgba/M75kOJSbZPRrhALBAe6o4gOYbV44afzFC/jUUp7dsA==",
       "dev": true,
       "requires": {
         "@docsearch/react": "^3.0.0-alpha.39",
-        "@docusaurus/core": "2.0.0-beta.5",
-        "@docusaurus/theme-common": "2.0.0-beta.5",
-        "@docusaurus/utils": "2.0.0-beta.5",
-        "@docusaurus/utils-validation": "2.0.0-beta.5",
+        "@docusaurus/core": "2.0.0-beta.6",
+        "@docusaurus/theme-common": "2.0.0-beta.6",
+        "@docusaurus/utils": "2.0.0-beta.6",
+        "@docusaurus/utils-validation": "2.0.0-beta.6",
         "algoliasearch": "^4.8.4",
         "algoliasearch-helper": "^3.3.4",
         "clsx": "^1.1.1",
@@ -29690,9 +29736,9 @@
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.5.tgz",
-      "integrity": "sha512-WtwR5O67cTK6wo9KnSxqBpgC26M6Z90PgX5Gun/Re8Ix+GVEqIzzev9C/2P2Da2TW0sgSkjWNr1tHaNxNMPLkQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.6.tgz",
+      "integrity": "sha512-TrwxyI93XTZEhOmdEI8FPKDbGV61zE9PzXCdE1alwz1NOV+YXwcv+9sRTZEVLqBpr+TIja+IeeS6mxnyen/Ptg==",
       "dev": true,
       "requires": {
         "commander": "^5.1.0",
@@ -29703,12 +29749,12 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.5.tgz",
-      "integrity": "sha512-hIzuARFMqXqljTdbF19bYRw+fqqK2gHlzepeC9uJfLLaGmirPFDPjr+BN9oiajBhNx2CgvJVl/66lEx4hrd7uQ==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.6.tgz",
+      "integrity": "sha512-S72/o7VDaTvrXJy+NpfuctghGGoMW30m94PMkrL3I6V+o5eE2Uzax7dbM++moclmHvi0/Khv+TXmRIQs6ZvwgQ==",
       "dev": true,
       "requires": {
-        "@docusaurus/types": "2.0.0-beta.5",
+        "@docusaurus/types": "2.0.0-beta.6",
         "@types/github-slugger": "^1.3.0",
         "chalk": "^4.1.1",
         "escape-string-regexp": "^4.0.0",
@@ -29722,22 +29768,22 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.5.tgz",
-      "integrity": "sha512-LUHEfZ9QGwBCpmGfLiPz5ENipxicsBlzIu+jUuB6I+ljX4Cd2OFkjDVmL0kjHR80sh0KJzNizpjsVj3l3jN9RA==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.6.tgz",
+      "integrity": "sha512-MKm6bJxvsYWRl072jLR60z+71tTWSxoERh2eTmCYlegFnu3Tby3HOC8I3jDcC6VpVuoDGsBGNoQbOgy2LqQbXQ==",
       "dev": true,
       "requires": {
-        "@docusaurus/types": "2.0.0-beta.5",
+        "@docusaurus/types": "2.0.0-beta.6",
         "tslib": "^2.2.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.5.tgz",
-      "integrity": "sha512-VWj1BRYejcGewWP3BKSm3a5dVzQWA9w9MDQUCylR2NxywOxonoUPo9nz5g9bN+C3rwuelfA5u3MORu2q2+rbLw==",
+      "version": "2.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.6.tgz",
+      "integrity": "sha512-v0nk9bpawUd2JFDFyiHDmZuMG+/O1UvxtxvcRbvrxrul+rlzD7Q9CGxMgW3Grp2OCKQ4yFXRidBIccwqON5AVw==",
       "dev": true,
       "requires": {
-        "@docusaurus/utils": "2.0.0-beta.5",
+        "@docusaurus/utils": "2.0.0-beta.6",
         "chalk": "^4.1.1",
         "joi": "^17.4.0",
         "tslib": "^2.1.0"
@@ -30383,9 +30429,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
-      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
+      "version": "17.0.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz",
+      "integrity": "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -30982,6 +31028,12 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -30989,15 +31041,15 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.3.tgz",
-      "integrity": "sha512-yRzjxfnggrP/+qVHlUuZz5FZzEbkT+Yt0/Df6ScEMnbbZBLzYB2W0KLxoQCW+THm1SpOsM1ZPcTHAwuvmibIsQ==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.6.tgz",
+      "integrity": "sha512-3bDjTfF0MfZntwVCSd18XAT2Zndufh3Mep+mafbzdIQEeWbncVRUVDjH8/EPANV9Hq40seJ24QcYAyhUsFz7gQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.8",
-        "caniuse-lite": "^1.0.30001252",
-        "colorette": "^1.3.0",
+        "browserslist": "^4.17.1",
+        "caniuse-lite": "^1.0.30001260",
         "fraction.js": "^4.1.1",
+        "nanocolors": "^0.2.8",
         "normalize-range": "^0.1.2",
         "postcss-value-parser": "^4.1.0"
       }
@@ -31304,16 +31356,16 @@
       }
     },
     "browserslist": {
-      "version": "4.16.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
-      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.2.tgz",
+      "integrity": "sha512-jSDZyqJmkKMEMi7SZAgX5UltFdR5NAO43vY0AwTpu4X3sGH7GLLQ83KiUomgrnvZRCeW0yPPnKqnxPqQOER9zQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001251",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.811",
+        "caniuse-lite": "^1.0.30001261",
+        "electron-to-chromium": "^1.3.854",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "nanocolors": "^0.2.12",
+        "node-releases": "^1.1.76"
       }
     },
     "buffer-from": {
@@ -31462,9 +31514,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001252",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+      "version": "1.0.30001264",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
+      "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
       "dev": true
     },
     "ccount": {
@@ -32452,9 +32504,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
       "dev": true,
       "peer": true
     },
@@ -32905,9 +32957,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.826",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.826.tgz",
-      "integrity": "sha512-bpLc4QU4B8PYmdO4MSu2ZBTMD8lAaEXRS43C09lB31BvYwuk9UxgBRXbY5OJBw7VuMGcg2MZG5FyTaP9u4PQnw==",
+      "version": "1.3.857",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.857.tgz",
+      "integrity": "sha512-a5kIr2lajm4bJ5E4D3fp8Y/BRB0Dx2VOcCRE5Gtb679mXIME/OFhWler8Gy2ksrf8gFX+EFCSIGA33FB3gqYpg==",
       "dev": true
     },
     "emoji-regex": {
@@ -33908,9 +33960,9 @@
       "dev": true
     },
     "flux": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.1.tgz",
-      "integrity": "sha512-emk4RCvJ8RzNP2lNpphKnG7r18q8elDYNAPx7xn+bDeOIo9FFfxEfIQ2y6YbQNmnsGD3nH1noxtLE64Puz1bRQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.2.tgz",
+      "integrity": "sha512-u/ucO5ezm3nBvdaSGkWpDlzCePoV+a9x3KHmy13TV/5MzOaCZDN8Mfd94jmf0nOi8ZZay+nOKbBUkOe2VNaupQ==",
       "dev": true,
       "requires": {
         "fbemitter": "^3.0.0",
@@ -35176,9 +35228,9 @@
       "dev": true
     },
     "infima": {
-      "version": "0.2.0-alpha.31",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.31.tgz",
-      "integrity": "sha512-ggOAeyiQIFKZeYnH9lbhDBHFZhcYOa0LFKSMLgot33X21aJRu7ruwVUVwYg4kJnZRLGLeAjC5BVgLxKoLixuNQ==",
+      "version": "0.2.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.33.tgz",
+      "integrity": "sha512-iLZI8/vGTbbhbeFhlWv1zwvrqfNDLAayuEdqZqNqCyGuh0IW469dRIRm0FLZ98YyLikt2njzuKfy6xUrBWRXcg==",
       "dev": true
     },
     "inflight": {
@@ -37071,6 +37123,12 @@
       "dev": true,
       "optional": true
     },
+    "nanocolors": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
+      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
+      "dev": true
+    },
     "nanoid": {
       "version": "3.1.23",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
@@ -37173,9 +37231,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "version": "1.1.77",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
       "dev": true
     },
     "normalize-package-data": {
@@ -38755,12 +38813,12 @@
       }
     },
     "postcss-sort-media-queries": {
-      "version": "3.11.12",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-3.11.12.tgz",
-      "integrity": "sha512-PNhEOWR/btZ0bNNRqqdW4TWxBPQ1mu2I6/Zpco80vBUDSyEjtduUAorY0Vm68rvDlGea3+sgEnQ36iQ1A/gG8Q==",
+      "version": "3.12.13",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-3.12.13.tgz",
+      "integrity": "sha512-bFbR1+P6HhZWXcT5DVV2pBH5Y2U5daKbFd0j+kcwKdzrxkbmgFu0GhI2JfFUyy5KQIeW+YJGP+vwNDOS5hIn2g==",
       "dev": true,
       "requires": {
-        "sort-css-media-queries": "1.5.4"
+        "sort-css-media-queries": "2.0.4"
       }
     },
     "postcss-sorting": {
@@ -39067,9 +39125,9 @@
       "requires": {}
     },
     "prismjs": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
+      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==",
       "dev": true
     },
     "process-nextick-args": {
@@ -39673,9 +39731,9 @@
       }
     },
     "reading-time": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.4.0.tgz",
-      "integrity": "sha512-0I9aP583rqQhm6T6Y+pYgYaM4w649VHgQPC24xSWXpn/4qRs08Zu6KgXRf0da6/k7IHoC6idm76fU6vz4mmzHQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
       "dev": true
     },
     "rechoir": {
@@ -45500,9 +45558,9 @@
       }
     },
     "sort-css-media-queries": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-1.5.4.tgz",
-      "integrity": "sha512-YP5W/h4Sid/YP7Lp87ejJ5jP13/Mtqt2vx33XyhO+IAugKlufRPbOrPlIiEUuxmpNBSBd3EeeQpFhdu3RfI2Ag==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.0.4.tgz",
+      "integrity": "sha512-PAIsEK/XupCQwitjv7XxoMvYhT7EAfyzI3hsy/MyDgTvc+Ft55ctdkctJLOy6cQejaIC+zjpUL4djFVm2ivOOw==",
       "dev": true
     },
     "sort-object-keys": {

--- a/package.json
+++ b/package.json
@@ -119,8 +119,8 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/core": "2.0.0-beta.5",
-    "@docusaurus/preset-classic": "2.0.0-beta.5",
+    "@docusaurus/core": "2.0.0-beta.6",
+    "@docusaurus/preset-classic": "2.0.0-beta.6",
     "@stylelint/prettier-config": "^2.0.0",
     "@stylelint/remark-preset": "^3.0.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #222

> Is there anything in the PR that needs further explanation?

See the [release note](https://github.com/facebook/docusaurus/releases/tag/v2.0.0-beta.6).

This update is created by the following command:

```sh
npm i -E @docusaurus/core@latest @docusaurus/preset-classic@latest
```
