### PR TITLE
Set `node-version` from `.nvmrc` file

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,10 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get Node.js version from .nvmrc
+        id: node-version
+        run: echo "::set-output name=value::$(< .nvmrc)"
+
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: '${{ steps.node-version.outputs.value }}'
           cache: npm
 
       - name: Install latest npm


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change aims to set the `node-version` parameter of `actions/setup-node` from the `.nvmrc` file.

https://github.com/stylelint/stylelint.io/blob/80a989497f02313e2b7f7e7cc1547812600b4a88/.nvmrc#L1