### PR TITLE
Copy image files in stylelint/stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,5 +133,8 @@
     "stylelint-config-standard": "^23.0.0",
     "stylelint-order": "^5.0.0",
     "unist-util-visit": "^4.1.0"
+  },
+  "engines": {
+    "node": ">=16"
   }
 }

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -172,6 +172,12 @@ function main(outputDir) {
 		fs.writeFileSync(outputFile, output, 'utf8');
 	});
 
+	glob.sync('node_modules/stylelint/*.png').forEach((imagePath) => {
+		const dest = path.join(outputDir, imagePath.replace('node_modules/stylelint/', ''));
+
+		fs.copyFileSync(imagePath, dest);
+	});
+
 	console.log('Documents have been generated.'); // eslint-disable-line no-console
 }
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- Related to stylelint/stylelint#5661

> Is there anything in the PR that needs further explanation?

[`fs.copyFileSync()`](https://nodejs.org/api/fs.html#fscopyfilesyncsrc-dest-mode) has been available since Node.js 14.
So, it is necessary to add `engines.node` into `package.json` for ESLint.

See also:
https://github.com/stylelint/stylelint/blob/7d34399828eb2a0a7230f955d012efccbb35b71a/README.md?plain=1#L27

