### PR TITLE
Limit dependabot PRs to 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-    open-pull-requests-limit: 5
-    versioning-strategy: increase
-    labels:
-      - 'pr: dependencies'
-  - package-ecosystem: npm
-    directory: '/website'
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     versioning-strategy: increase
     labels:
       - 'pr: dependencies'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

It's easier to update the deps for this repo in one go (as, for example, the two docusaurus packages are linked).

This pull request drops the limit to one (so that the pull requests acts more like a reminder to update than anything else).
