### PR TITLE
Stop updating React via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     versioning-strategy: increase
     labels:
       - 'pr: dependencies'
+    # TODO: We cannot update React to v18. See https://github.com/facebook/docusaurus/issues/7264
+    ignore:
+      - dependency-name: 'react'
+        versions: ['18.x']


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #277

> Is there anything in the PR that needs further explanation?

Until Docusaurus supports React 18, we cannot update.
See https://github.com/facebook/docusaurus/issues/7264
