### PR TITLE
Add Netlify status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # stylelint.io
 
 [![Build Status](https://github.com/stylelint/stylelint.io/workflows/CI/badge.svg)](https://github.com/stylelint/stylelint.io)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/60ebb875-d403-4ace-b0b4-ebc58b3361e1/deploy-status)](https://app.netlify.com/sites/stylelint/deploys)
 
 The source of stylelint website. To edit content, go to the main repository's [documentation folder](https://github.com/stylelint/stylelint/tree/main/docs).
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change will allow us to access Netlify easily and view the Netlify build status.
