### PR TITLE
Use Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     versioning-strategy: increase
     labels:
       - 'pr: dependencies'
@@ -12,3 +12,14 @@ updates:
     ignore:
       - dependency-name: 'react'
         versions: ['18.x']
+    groups:
+      docusaurus:
+        patterns: ['@docusaurus/*']
+      react:
+        patterns: ['react', 'react-dom']
+      development-dependencies:
+        dependency-type: 'development'
+        exclude-patterns:
+          - '@docusaurus/*'
+          - 'stylelint'
+          - 'stylelint-config-standard'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change makes Dependabot Pull Requests more efficient by grouping relevant dependencies' updates.

Also, this increases `open-pull-requests-limit` because this limit's purpose is to reduce Dependabot PR noises.
This limitation will not make sense so much if using the group updates.

See also:
- [`dependabot.yml` reference](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- This repository's `package.json`:
 https://github.com/stylelint/stylelint.io/blob/d57da950f03e323d1058e296308c6b985098352e/package.json#L82-L106
