### PR TITLE
Dependabot ignore `react-dom@18.x` like `react`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     ignore:
       - dependency-name: 'react'
         versions: ['18.x']
+      - dependency-name: 'react-dom'
+        versions: ['18.x']
     groups:
       docusaurus:
         patterns: ['@docusaurus/*']


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #341

> Is there anything in the PR that needs further explanation?

This PR will prevent useless PRs like #344 about React package updates.
