### PR TITLE
Update Dependabot group for Docusaurus and React

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,10 @@ updates:
     versioning-strategy: increase
     labels:
       - 'pr: dependencies'
-    # TODO: We cannot update React to v18. See https://github.com/facebook/docusaurus/issues/7264
-    ignore:
-      - dependency-name: 'react'
-        versions: ['18.x']
-      - dependency-name: 'react-dom'
-        versions: ['18.x']
     groups:
-      docusaurus:
-        patterns: ['@docusaurus/*']
-      react:
-        patterns: ['react', 'react-dom']
+      # Note: React is a peer dependency of Docusaurus.
+      docusaurus-and-react:
+        patterns: ['@docusaurus/*', 'react', 'react-dom']
       development-dependencies:
         dependency-type: 'development'
         exclude-patterns:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #354

> Is there anything in the PR that needs further explanation?

Docusaurus 3.0 is out. See https://docusaurus.io/blog/releases/3.0

We can now update React to 18:

```console
$ npm view @docusaurus/core peerDependencies
{ react: '^18.0.0', 'react-dom': '^18.0.0' }
```

So, updating Docusaurus and React simultaneously should be better.
