### PR TITLE
Remove parse error hack for `CHANGELOG.md`

### DIFF
--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -214,16 +214,6 @@ function main(outputDir) {
 		);
 
 		fs.mkdirSync(path.dirname(outputFile), { recursive: true });
-
-		// TODO: Prevent the parse error. Remove this code when the error is fixed.
-		if (outputFile.endsWith('CHANGELOG.md')) {
-			output = output.replace(' #{&}', ' `#{&}`');
-
-			console.warn(
-				`Warning: The parse error in '${outputFile}' was prevented: 'Could not parse expression with acorn'.`,
-			); // eslint-disable-line no-console
-		}
-
 		fs.writeFileSync(outputFile, output, 'utf8');
 	});
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #357

> Is there anything in the PR that needs further explanation?

This PR removes the no longer needed hack for a parse error in `CHANGELOG.md`. The error cause has been already removed in the stylelint/stylelint repository.

Note: We need to merge this PR when releasing the next Stylelint version.

See also:
- https://github.com/stylelint/stylelint.io/pull/357/files/57b7a897853ec527667f73a7c357d679b88b9cdc#r1379011358
- https://github.com/stylelint/stylelint/pull/7292

