### PR TITLE
Fix syntax highlighting in code blocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,6 +68,10 @@ const config = {
 			apiKey: '2164fcb348ebad562ba0340da4760f25',
 			indexName: 'stylelint',
 		},
+		prism: {
+			// See https://prismjs.com/#supported-languages
+			additionalLanguages: ['bash', 'css', 'diff', 'json', 'markdown', 'shell-session'],
+		},
 	},
 	plugins: [
 		// Sets response headers for development.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #357

> Is there anything in the PR that needs further explanation?

I upgraded Docusaurus to v3 in #357, but I missed a breaking change for syntax highlighting.
This change adds the `prism.additionalLanguages` to the Docusaurus config.

See also:
- https://docusaurus.io/docs/migration/v3#prism-react-renderer-v20
- https://prismjs.com/#supported-languages

| Path | Before (stylelint.io) | After (this PR preview) |
|--------|--------|--------|
| `/user-guide/customize` | <img width="546" alt="image" src="https://github.com/stylelint/stylelint.io/assets/473530/e9057338-4952-4d54-aeee-6d6aefc67e10"> | <img width="524" alt="image" src="https://github.com/stylelint/stylelint.io/assets/473530/43387826-372a-49e3-9943-e7b24718e749"> |
| `/configure` | <img width="322" alt="image" src="https://github.com/stylelint/stylelint.io/assets/473530/2977ad23-118b-47ad-b5ba-f70315cf5b77"> | <img width="320" alt="image" src="https://github.com/stylelint/stylelint.io/assets/473530/7d9bfc74-727e-435c-af5f-b5e36cb9c2b6"> | 