### PR TITLE
Add missing permissions for peter-evans/create-pull-request@v5

### DIFF
--- a/.github/workflows/update-awesome-stylelint.yml
+++ b/.github/workflows/update-awesome-stylelint.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   update-awesome-stylelint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR fixes the error with the "Update Awesome Stylelint" workflow. See the log:

```
/usr/bin/git push --force-with-lease origin create-pull-request/patch:refs/heads/create-pull-request/patch
remote: Permission to stylelint/stylelint.io.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/stylelint/stylelint.io/': The requested URL returned error: 403
Error: The process '/usr/bin/git' failed with exit code 128
```

-- https://github.com/stylelint/stylelint.io/actions/runs/7369219181/job/20054275649#step:6:89

See also https://github.com/peter-evans/create-pull-request/issues/1873

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #374

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
