### PR TITLE
Automate releasing via GitHub action

### DIFF
--- a/.github/workflows/release-stylelint.yml
+++ b/.github/workflows/release-stylelint.yml
@@ -1,0 +1,36 @@
+name: Release Stylelint
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Update Stylelint
+        id: update-stylelint
+        run: |
+          new_version="$(npm view stylelint version)"
+          npm install "https://github.com/stylelint/stylelint/tarball/${new_version}" --save-dev
+          echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
+      - name: Test
+        run: npm test
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Release ${{ steps.update-stylelint.outputs.new_version }}
+          title: Release ${{ steps.update-stylelint.outputs.new_version }}
+          body: |
+            See https://github.com/stylelint/stylelint/releases/tag/${{ steps.update-stylelint.outputs.new_version }}

--- a/.github/workflows/update-awesome-stylelint.yml
+++ b/.github/workflows/update-awesome-stylelint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version-file: .nvmrc
           cache: npm
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This change automates releasing described in our maintainer guide:
https://github.com/stylelint/stylelint/blob/f4c75c911275f7c972f285495c6e037c2731981e/docs/maintainer-guide/releases.md?plain=1#L22-L28

A new workflow to update the website will be:
1. Go to this action page in `stylelint/stylelint.io`
2. Click **Run workflow**
3. Check a pull request created automatically
4. Merge the pull request

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

We could add a GitHub workflow in `stylelint/stylelint`. But if doing so, we'd need an access token to create a pull request in `stylelint/stylelint.io`. Because managing an access token might be troublesome, I didn't adopt this idea.
