### PR TITLE
Specify custom branch to `peter-evans/create-pull-request` action

### DIFF
--- a/.github/workflows/release-stylelint.yml
+++ b/.github/workflows/release-stylelint.yml
@@ -34,3 +34,4 @@ jobs:
           title: Release ${{ steps.update-stylelint.outputs.new_version }}
           body: |
             See https://github.com/stylelint/stylelint/releases/tag/${{ steps.update-stylelint.outputs.new_version }}
+          branch: release-${{ steps.update-stylelint.outputs.new_version }}

--- a/.github/workflows/update-awesome-stylelint.yml
+++ b/.github/workflows/update-awesome-stylelint.yml
@@ -30,3 +30,4 @@ jobs:
           title: Update Awesome Stylelint
           body: |
             This pull request updates [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint).
+          branch: update-awesome-stylelint


### PR DESCRIPTION
By default, `peter-evans/create-pull-request` creates a branch named `create-pull-request/patch`. This is ambiguous and may conflict.

See https://github.com/peter-evans/create-pull-request#action-inputs

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
