### PR TITLE
Exclude ESLint from Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
           - '@docusaurus/*'
           - 'stylelint'
           - 'stylelint-config-standard'
+          - 'eslint'
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #412

> Is there anything in the PR that needs further explanation?

To avoid dependency problems of ESLint v9.
