### PR TITLE
Convert `jsonc` to `json` in code blocks

### DIFF
--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -100,12 +100,26 @@ function makeRuleSymbolsAccessbile() {
 	return transform;
 }
 
+// NOTE: Prism doesn't support JSONC.
+function jsoncToJson() {
+	function visitor(node) {
+		node.lang = 'json';
+	}
+
+	function transform(tree) {
+		visit(tree, { type: 'code', lang: 'jsonc' }, visitor);
+	}
+
+	return transform;
+}
+
 function processMarkdown(file, { rewriter }) {
 	const content = remark()
 		.use(remarkGFM)
 		.use(rewriteLink, { rewriter })
 		.use(wrapProblemExample)
 		.use(makeRuleSymbolsAccessbile)
+		.use(jsoncToJson)
 		.processSync(fs.readFileSync(file, 'utf8'))
 		.toString();
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Necessary for https://github.com/stylelint/stylelint/pull/7983

> Is there anything in the PR that needs further explanation?

Prism doesn't support JSONC, but its syntax highlighting works for comments in JSON.
So, this change converts automatically `jsonc` to `json` in Markdown code blocks.

See also https://prismjs.com/#supported-languages

|Before|After|
|-|-|
|<img width="547" alt="image" src="https://github.com/user-attachments/assets/d4874ed0-d4e8-49c2-b117-e27fe8717f30">|<img width="447" alt="image" src="https://github.com/user-attachments/assets/af9ca007-c9df-4af6-828d-4e4b4dfab530">|
