### PR TITLE
Revert 413 - include ESLint in dependabot dev group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
           - '@docusaurus/*'
           - 'stylelint'
           - 'stylelint-config-standard'
-          - 'eslint'
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

We can include it again now that we use ESLint 9.x
