### PR TITLE
Fix Home nav item

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,9 +46,9 @@ const config = {
 			items: [
 				{
 					to: '/',
-					label: 'Docs',
+					label: 'Home',
 					position: 'left',
-					activeBaseRegex: '^(?!/user-guide/rules|/demo)',
+					activeBaseRegex: '^/$',
 				},
 				{
 					to: '/user-guide/rules',


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

When we added the "Rules" nav item, it caused a confusing active state for the "Docs" nav item:

<img width="393" alt="Screenshot 2024-12-26 at 23 31 56" src="https://github.com/user-attachments/assets/85c6e97c-1491-4c3a-a3aa-d7879ab85650" />

This PR renames the first item "Home" and only activates it on that specific page so the behaviour is the same as the "Rules" and "Demo" nav item.


