### PR TITLE
Fix light theme code blocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,3 +1,4 @@
+import { themes as prismThemes } from 'prism-react-renderer'; // eslint-disable-line n/no-extraneous-import
 import remarkGithubAdmonitionsToDirectives from 'remark-github-admonitions-to-directives';
 
 /** @type {import('@docusaurus/types').Config} */
@@ -83,6 +84,8 @@ const config = {
 			indexName: 'stylelint',
 		},
 		prism: {
+			theme: prismThemes.github,
+			darkTheme: prismThemes.palenight,
 			// See https://prismjs.com/#supported-languages
 			additionalLanguages: ['bash', 'css', 'diff', 'json', 'markdown', 'shell-session'],
 		},

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,11 +6,11 @@
 }
 
 .valid-pattern .prism-code {
-	box-shadow: 0 -3px 0 0 green !important;
+	box-shadow: inset 3px 0 0 0 forestgreen !important;
 }
 
 .invalid-pattern .prism-code {
-	box-shadow: 0 -3px 0 0 crimson !important;
+	box-shadow: inset 3px 0 0 0 firebrick !important;
 }
 
 /* Hide generated list of rules in sidebar */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Uses a light prism theme for code blocks in light mode. The Docusaurus site does the same, but the classic theme default does not.

Places the valid/invalid pattern indicator to the side for better compatibility with the two themes:

<img width="679" alt="Screenshot 2024-12-27 at 00 17 43" src="https://github.com/user-attachments/assets/aa5a861f-12c4-4630-99fe-270a6421fc77" />

