### PR TITLE
Harden `npm install` security

### DIFF
--- a/.github/workflows/update-awesome-stylelint.yml
+++ b/.github/workflows/update-awesome-stylelint.yml
@@ -37,7 +37,9 @@ jobs:
           echo "version=${current_version}" >> "${GITHUB_OUTPUT}"
 
       - name: Update Awesome Stylelint
-        run: npm update awesome-stylelint
+        run: |
+          new_sha=$(git ls-remote https://github.com/stylelint/awesome-stylelint.git HEAD | cut -f1)
+          npm install --save-dev "awesome-stylelint@https://github.com/stylelint/awesome-stylelint/tarball/${new_sha}"
 
       - name: Get new version
         id: new

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,5 @@
-engine-strict=true
+# NOTE: Allow git to fetch awesome-stylelint from GitHub.
+allow-git = "all"
+engine-strict = true
+ignore-scripts = true
+min-release-age = 3 # days

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,4 @@
-# NOTE: Allow git to fetch awesome-stylelint from GitHub.
-allow-git = "all"
+allow-git = "none"
 engine-strict = true
 ignore-scripts = true
 min-release-age = 3 # days

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@stylelint/prettier-config": "^4.0.0",
         "@stylelint/remark-preset": "^5.1.1",
-        "awesome-stylelint": "github:stylelint/awesome-stylelint",
+        "awesome-stylelint": "https://github.com/stylelint/awesome-stylelint/tarball/ee4f999f235bd46a9c92d4ac5b0e8852d217b41e",
         "eslint": "^10.2.1",
         "eslint-config-stylelint": "^27.0.0",
         "glob": "^13.0.6",
@@ -7144,7 +7144,8 @@
     },
     "node_modules/awesome-stylelint": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/stylelint/awesome-stylelint.git#ee4f999f235bd46a9c92d4ac5b0e8852d217b41e",
+      "resolved": "https://github.com/stylelint/awesome-stylelint/tarball/ee4f999f235bd46a9c92d4ac5b0e8852d217b41e",
+      "integrity": "sha512-ZZezLoS7xezhG/yQKOCzDHg/XmcWK0xS5tFuCEwrUnsXWazSB4oooiMCrzgQSYbn+nk4y1EJjwXS1CWT8KK8sA==",
       "dev": true
     },
     "node_modules/babel-loader": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@stylelint/prettier-config": "^4.0.0",
     "@stylelint/remark-preset": "^5.1.1",
-    "awesome-stylelint": "github:stylelint/awesome-stylelint",
+    "awesome-stylelint": "https://github.com/stylelint/awesome-stylelint/tarball/ee4f999f235bd46a9c92d4ac5b0e8852d217b41e",
     "eslint": "^10.2.1",
     "eslint-config-stylelint": "^27.0.0",
     "glob": "^13.0.6",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Same as stylelint/stylelint-config-standard#413

> Is there anything in the PR that needs further explanation?

Add two flags to `.npmrc` to reduce supply-chain risk:

- `ignore-scripts = true` — skip lifecycle scripts on install.
- `min-release-age = 3` — only install package versions at least 3 days old.

~~Note: We cannot specify `allow-git = "none"` to fetch awesome-stylelint from GitHub.~~
We can use `allow-git = "none"` by the `awesome-stylelint` dependency URL, ref 7e77930 & a430a0a:
```diff
-    "awesome-stylelint": "github:stylelint/awesome-stylelint",
+    "awesome-stylelint": "https://github.com/stylelint/awesome-stylelint/tarball/ee4f999f235bd46a9c92d4ac5b0e8852d217b41e",
```

Note: contributors must run `npm run prepare` manually post-clone to set the local git hooks path, since `ignore-scripts` skips the `prepare` script.

Ref: https://github.com/lirantal/npm-security-best-practices/blob/a98aeb7197d3820686337f28ea96ffe94333457b/README.md
