### PR TITLE
Add user guide page redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,6 +29,10 @@
   to = "/contributor-guide/system-tests"
 
 [[redirects]]
+  from = "/user-guide"
+  to = "/#guides"
+
+[[redirects]]
   from = "/user-guide/usage/cli"
   to = "/user-guide/cli"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@
 
 [[redirects]]
   from = "/user-guide"
-  to = "/#guides"
+  to = "/user-guide/get-started"
 
 [[redirects]]
   from = "/user-guide/usage/cli"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix (of sorts...). Although I can create an issue if needed.

> Is there anything in the PR that needs further explanation?

Stylelint.io used to have a dedicated user guide page:
* Stylelint.io page URL: https://stylelint.io/user-guide/
* Wayback Machine (latest snapshot): https://web.archive.org/web/20191206074839/https://stylelint.io/user-guide/
* GitHub HTML page (archived repo): https://github.com/stylelint/stylelint.github.io/blob/master/user-guide/index.html

Many GitHub repos still link to it to this day:
* https://github.com/search?type=code&q=stylelint.io%2Fuser-guide%29 (11 hits)
* https://github.com/search?type=code&q=stylelint.io%2Fuser-guide%2F%29 (410 hits)
* https://github.com/search?type=code&q=https%3A%2F%2Fstylelint.io%2Fuser-guide%2F%22 (3 hits)

However, the user guide page appears to have gone missing in February 2020, around the time stylelint.io's menu was redesigned.

This deals with it by adding a redirect to the user guide's setting started page (https://stylelint.io/user-guide/get-started).