### PR TITLE
Update `allow-git`/`allow-remote` in `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
-allow-git = "none"
+allow-git = "root"
+allow-remote = "root"
 engine-strict = true
 ignore-scripts = true
 min-release-age = 3 # days


### PR DESCRIPTION
<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR fixes the CI failure due to the `EALLOWREMOTE` error: <https://github.com/stylelint/stylelint.io/actions/runs/28990768986/job/86029800519#step:5:5>

Because npm v12.0.0 has changed the default value of `allow-git`/`allow-remote` to `"none"`: https://github.com/npm/cli/releases/tag/v12.0.0

Since this repo doesn't publish any packages, allowing remote packages is safe.

