### PR TITLE
Remove `ready_for_review` workaround from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      # NOTE: The purpose of `ready_for_review` is to trigger workflow runs when a pull request is created in GitHub Actions.
-      # See https://github.com/peter-evans/create-pull-request/blob/v7/docs/concepts-guidelines.md#triggering-further-workflow-runs
-      - ready_for_review
 
 jobs:
   lint:

--- a/.github/workflows/release-stylelint.yml
+++ b/.github/workflows/release-stylelint.yml
@@ -47,4 +47,3 @@ jobs:
             See https://github.com/stylelint/stylelint/releases/tag/${{ steps.update-stylelint.outputs.new-version }}
           branch: release/${{ steps.update-stylelint.outputs.new-version }}
           sign-commits: true
-          draft: always-true


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Bot-created pull requests can now run workflows if approved. So the `ready_for_review` trigger in `ci.yml` and the `draft: always-true` option in `release-stylelint.yml` are no longer needed.

See:
https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/
